### PR TITLE
Closes #68 Add cart related models to the SDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ osx_image: xcode8
 
 xcode_sdk: iphonesimulator10.0
 
-script: xcodebuild -workspace Commercetools.xcworkspace -scheme "Commercetools" -destination "platform=iOS Simulator,name=iPhone 6" test | xcpretty -f `xcpretty-travis-formatter`
+script: xcodebuild -workspace Commercetools.xcworkspace -scheme "Commercetools" -destination "platform=iOS Simulator,name=iPhone 6" test
 
 deploy:
   provider: script

--- a/Commercetools.podspec
+++ b/Commercetools.podspec
@@ -11,5 +11,6 @@ Pod::Spec.new do |s|
   s.source_files = 'Source/**/*.swift'
 
   s.dependency 'Alamofire', '~> 4.0'
+  s.dependency 'ObjectMapper', '~> 2.0'
 
 end

--- a/Commercetools.xcodeproj/project.pbxproj
+++ b/Commercetools.xcodeproj/project.pbxproj
@@ -9,33 +9,90 @@
 /* Begin PBXBuildFile section */
 		210BE01F162E3933AA6871EF /* CreateEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEF34FFFADD720A136729 /* CreateEndpoint.swift */; };
 		210BE035746D461EF781B601 /* UpdateByKeyEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEB5FEB721BD118FB29D5 /* UpdateByKeyEndpoint.swift */; };
+		210BE0454C553693B732F5EA /* ZoneRate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEFDB770916BB1DDCEB4E /* ZoneRate.swift */; };
+		210BE0765D49BC5CEC7BC341 /* PaymentInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE3E01399DE690C9E29F3 /* PaymentInfo.swift */; };
 		210BE0FB35AF665054D028C4 /* Commercetools.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE7EF595235524206718F /* Commercetools.swift */; };
+		210BE1237FACC3260C5BF4BB /* ItemState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE340163DD6D9479ECA94 /* ItemState.swift */; };
+		210BE13FBA1E33EE1FF7103D /* LineItemPriceMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEDDD266CE08EBEFEC1E8 /* LineItemPriceMode.swift */; };
+		210BE1714C5D46C856FD5E42 /* CustomerGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE97FE140122183D67ED7 /* CustomerGroup.swift */; };
 		210BE1B77F7D1AB5026075DA /* DeleteEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEBE03DA0A2EEB49D3DA2 /* DeleteEndpointTests.swift */; };
+		210BE1B83F1A1B1CCE1A10BA /* Delivery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE5C8BF973677F5E53C98 /* Delivery.swift */; };
+		210BE1E69F54FD25B4321EF5 /* InventoryMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE6287015A18476C288FA /* InventoryMode.swift */; };
+		210BE266E1578CD09A4B5D7E /* CartState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEF0359B7130545B6C576 /* CartState.swift */; };
 		210BE27112B084029788BD8A /* QueryEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE774D4E1BC8C46FE54F1 /* QueryEndpointTests.swift */; };
+		210BE2C718C9460DB6549702 /* State.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BED7B56DBE214863A4ABB /* State.swift */; };
 		210BE2CBF45130959D9E2843 /* ByKeyEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE6DAAB250113B9FC53CF /* ByKeyEndpoint.swift */; };
+		210BE2F3F552DCAB853DC30E /* DiscountCodeState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEA79B4FA8CDFF3BA78D5 /* DiscountCodeState.swift */; };
 		210BE2F771FF1894369D01B5 /* UpdateEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEC9E16C430A31F462309 /* UpdateEndpoint.swift */; };
 		210BE30354065747CA48F92C /* ProductProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEB9F8FEDA82BE1A8C60E /* ProductProjection.swift */; };
+		210BE3058C8068A0C2650C4B /* TaxCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE1D33B6104781CA48829 /* TaxCategory.swift */; };
 		210BE317383AF01BE274933A /* Customer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE57902D25B9BD0342A69 /* Customer.swift */; };
+		210BE33C8A2E3C9591C5E23D /* Transaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE3B8176821E9358D02D2 /* Transaction.swift */; };
 		210BE35D4CAA2F56F2E62062 /* QueryEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE75EF663DC6979FE0FCF /* QueryEndpoint.swift */; };
+		210BE374F7A32C4D7BA99BFE /* DiscountedLineItemPrice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE529D940FF5B7B41090A /* DiscountedLineItemPrice.swift */; };
+		210BE37BB47291253613E607 /* DiscountedLineItemPriceForQuantity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE5C490469B5F6E9A6F48 /* DiscountedLineItemPriceForQuantity.swift */; };
+		210BE37EBA33C93099FA8827 /* DiscountedPrice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BED5F353303DA7B5B783C /* DiscountedPrice.swift */; };
+		210BE38E327F9506FC0A9998 /* ProductVariantAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE67367EDD97EE6BD0EBE /* ProductVariantAvailability.swift */; };
 		210BE3925983FE6D33226BD1 /* DeleteEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE80A6E99FC9F608AC3A6 /* DeleteEndpoint.swift */; };
+		210BE3B4DBAC4A11709B6556 /* Parcel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEEA309294925C55F36D8 /* Parcel.swift */; };
 		210BE40C5DD231FC289ACC9F /* ByIdEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE12054F8D0CB0147CBD9 /* ByIdEndpoint.swift */; };
+		210BE42B33BAC3F1A224846C /* Payment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE0C38CA3F227B1FEF646 /* Payment.swift */; };
 		210BE46ADE08AB809FFB22DD /* ProductType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE258C80D22ECAA4660A4 /* ProductType.swift */; };
+		210BE536AB7ED419A07D88D8 /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE77717A599BDC7139F3F /* Image.swift */; };
+		210BE53DF2703D96FFF2919F /* TransactionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE18DB940A25ADCA2D301 /* TransactionState.swift */; };
+		210BE54F79BF27BFFCF60998 /* CartDiscountValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE6B1EEF59FD0DAC2E8E9 /* CartDiscountValue.swift */; };
+		210BE576BDE9EF6C87248983 /* ChannelRole.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEDA866AE8388BED6DB32 /* ChannelRole.swift */; };
+		210BE577E4E65FDD58C68840 /* TaxedItemPrice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BED9CFCFD1221B5DC110C /* TaxedItemPrice.swift */; };
+		210BE598AD2157B642AA3A72 /* StateType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEBE060BABF8FDD751F43 /* StateType.swift */; };
+		210BE5F129026F44D837CCED /* AttributeDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEFA52DA4F82DDAA860C2 /* AttributeDefinition.swift */; };
+		210BE5FC5FD05550C134289E /* DiscountCodeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE2A14BC8A54E6A803EB7 /* DiscountCodeInfo.swift */; };
+		210BE61C136463F5568A25CC /* Reference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE9A116673BA1D5E758FF /* Reference.swift */; };
 		210BE66645DA622BEE3ED25A /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEEDD69E4AAC50AE994C4 /* Category.swift */; };
+		210BE683AE4D4FA463B8354D /* SubRate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE1E119ACC6A0229139F6 /* SubRate.swift */; };
 		210BE69C056B75CF70357AFF /* UpdateEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEEF193D03D0E260EF170 /* UpdateEndpointTests.swift */; };
+		210BE6A79E9699D396DF5EE0 /* Attribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE03BD07142FA05844846 /* Attribute.swift */; };
 		210BE6C3063D6C460F6D8601 /* Order.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE4DCEEE2B368FC013FF0 /* Order.swift */; };
+		210BE6F3C54B989B55F7BFB5 /* ShippingInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEEEFC28FE8E382F62D64 /* ShippingInfo.swift */; };
+		210BE7C6DE425E7C3D406D86 /* TaxRate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE0C5257F3269595A8617 /* TaxRate.swift */; };
 		210BE7E502CA456C30566881 /* CTError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE57833F74D2656716AF8 /* CTError.swift */; };
 		210BE80CB72C73E5D330AA32 /* Cart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE3AEF096B27E48F86A4B /* Cart.swift */; };
+		210BE80F25E51727BADFF914 /* DiscountedLineItemPortion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE2853D7DC183E939471B /* DiscountedLineItemPortion.swift */; };
+		210BE86F7775A5AF26BF088B /* CustomLineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE2531CF6F3C1B345E202 /* CustomLineItem.swift */; };
+		210BE886787B66312EC6FEDC /* TransactionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEF046B415B548D289A3F /* TransactionType.swift */; };
+		210BE971C2751BFAF5B11D8A /* TrackingData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE8BF8309FF6BAB244FC8 /* TrackingData.swift */; };
 		210BE9B7A4D7D1BE572FE27D /* ActiveCart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE4751F066B02CE24C3BF /* ActiveCart.swift */; };
+		210BE9C4A49D0522D83F49EB /* AttributeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE5FE86DEEF15BBB326B9 /* AttributeType.swift */; };
 		210BE9F03FC6EB74CA205C35 /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEAADF7135452064FD935 /* Log.swift */; };
 		210BE9FDDE49F1D7D4F53430 /* UpdateByKeyEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEC0502A7456AB50DC1B1 /* UpdateByKeyEndpointTests.swift */; };
+		210BEA074EAD575F57C3A5C5 /* LineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE30D704D107A518AC4E9 /* LineItem.swift */; };
+		210BEA1170C392AA36907B63 /* StateRole.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE9449BBF4A8DD0B7B09E /* StateRole.swift */; };
 		210BEA16377561C1FC741F28 /* CreateEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEF918E99658EE26EA2EE /* CreateEndpointTests.swift */; };
+		210BEA9A3DDB3216E94A6152 /* Zone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEF391627F9DE1730CC16 /* Zone.swift */; };
+		210BEAF3789CFF3898152D79 /* Location.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE4E18D39AAC4D717A979 /* Location.swift */; };
+		210BEB5CFFA25C9B2F702751 /* PaymentMethodInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEBF406AB4C5BABCAA58B /* PaymentMethodInfo.swift */; };
 		210BEBAB76278A85D14568D0 /* ByKeyEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE6AA937472A9A87BA7CF /* ByKeyEndpointTests.swift */; };
+		210BEBF11EC76D94CCF45358 /* TaxMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEA38F1A3754058F16FDC /* TaxMode.swift */; };
+		210BEC69714EE2F07B77F5A5 /* ShippingMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE45EE3CF66D8CDC3C635 /* ShippingMethod.swift */; };
+		210BEC975581F978049C5C76 /* ParcelMeasurements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEE448CC3B247AA1F8350 /* ParcelMeasurements.swift */; };
+		210BECC47AA7F5A62607A33F /* ShippingRate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE01056F4E128E522C7E7 /* ShippingRate.swift */; };
 		210BED47512A21301ACEFE86 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE2D37FC5D53E1528CEBB /* Result.swift */; };
+		210BED7587E729A08770D802 /* ProductVariant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEBB7A0793F288DF820AA /* ProductVariant.swift */; };
+		210BED8D87FC3DC6108ECCE1 /* ReviewRatingStatistics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BED939684FBFABFD06355 /* ReviewRatingStatistics.swift */; };
 		210BEDC4D05E071DA9248E17 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE36824D8A23C8CFDB13F /* Config.swift */; };
 		210BEDE9A321298095FE617F /* ByIdEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEFF22F11C1A9EE22C1E1 /* ByIdEndpointTests.swift */; };
+		210BEE1DD44E871B71E628D3 /* DeliveryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE7807F6B8C042C8F6F69 /* DeliveryItem.swift */; };
+		210BEE20EDE0493C6171F206 /* CartDiscountTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE87AB39F8703A7C83831 /* CartDiscountTarget.swift */; };
+		210BEE339332A06E80D3C098 /* Address.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE713166F1B45AFDDAD45 /* Address.swift */; };
+		210BEE5E101C0C9FBEE2631E /* TaxedPrice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEC5B0CA7B043DA3B6C93 /* TaxedPrice.swift */; };
 		210BEE7F0EF61808761BDBB5 /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE69087D43E8630A27203 /* AuthManager.swift */; };
+		210BEEA91E37EFD61DD9FED0 /* Channel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEAABCBDF178FC0D01D3C /* Channel.swift */; };
+		210BEEAB90E24376A22ADF19 /* Price.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE2D19F484AAD355FFAD4 /* Price.swift */; };
+		210BEEB01644FDD20B770E53 /* Money.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE05E98486D4447F83690 /* Money.swift */; };
+		210BEEF7F6C9AE602CCA443B /* PaymentStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE527FE929BB31797E084 /* PaymentStatus.swift */; };
 		210BEF7772BC10CA87E61644 /* TokenStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEF4B389CAF21987D0F00 /* TokenStore.swift */; };
 		210BEFC6EB3105F2FC9CEDA1 /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEA9FB39CC0B4C382E087 /* Endpoint.swift */; };
+		210BEFC77DAD1E64B738E641 /* DiscountCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE59473D4429CE5E4C1CD /* DiscountCode.swift */; };
+		210BEFD6D276BC91DFE3F4EE /* CartDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE58B423D68B439480AF2 /* CartDiscount.swift */; };
 		2111C3F51CD7831D00B2C082 /* CustomerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2111C3F41CD7831D00B2C082 /* CustomerTests.swift */; };
 		211B59371CC77C7200246522 /* CommercetoolsTestConfig.plist in Resources */ = {isa = PBXBuildFile; fileRef = 211B59361CC77C7200246522 /* CommercetoolsTestConfig.plist */; };
 		213398191CDB8BB2003248BD /* ProductProjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213398181CDB8BB2003248BD /* ProductProjectionTests.swift */; };
@@ -43,21 +100,6 @@
 		21C6080A1CE006EE001A68A7 /* Commercetools.h in Headers */ = {isa = PBXBuildFile; fileRef = 21C608081CE006EE001A68A7 /* Commercetools.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		21C6534D1CBE6292008E84B2 /* Commercetools.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 21C653421CBE6291008E84B2 /* Commercetools.framework */; };
 		21C653521CBE6292008E84B2 /* AuthManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C653511CBE6292008E84B2 /* AuthManagerTests.swift */; };
-		21C81E2D1D9C916E000D9BAF /* LineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C81E2C1D9C916E000D9BAF /* LineItem.swift */; };
-		21C81E371D9C9228000D9BAF /* DiscountedLineItemPrice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C81E2E1D9C9228000D9BAF /* DiscountedLineItemPrice.swift */; };
-		21C81E381D9C9228000D9BAF /* DiscountedLineItemPriceForQuantity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C81E2F1D9C9228000D9BAF /* DiscountedLineItemPriceForQuantity.swift */; };
-		21C81E391D9C9228000D9BAF /* DiscountedPrice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C81E301D9C9228000D9BAF /* DiscountedPrice.swift */; };
-		21C81E3A1D9C9228000D9BAF /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C81E311D9C9228000D9BAF /* Image.swift */; };
-		21C81E3B1D9C9228000D9BAF /* Money.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C81E321D9C9228000D9BAF /* Money.swift */; };
-		21C81E3C1D9C9228000D9BAF /* Price.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C81E331D9C9228000D9BAF /* Price.swift */; };
-		21C81E3D1D9C9228000D9BAF /* ProductVariant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C81E341D9C9228000D9BAF /* ProductVariant.swift */; };
-		21C81E3E1D9C9228000D9BAF /* ProductVariantAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C81E351D9C9228000D9BAF /* ProductVariantAvailability.swift */; };
-		21C81E3F1D9C9228000D9BAF /* TaxedPrice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C81E361D9C9228000D9BAF /* TaxedPrice.swift */; };
-		21C81E411D9C92FB000D9BAF /* Channel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C81E401D9C92FB000D9BAF /* Channel.swift */; };
-		21C81E451D9C945E000D9BAF /* Attribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C81E421D9C945E000D9BAF /* Attribute.swift */; };
-		21C81E461D9C945E000D9BAF /* AttributeDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C81E431D9C945E000D9BAF /* AttributeDefinition.swift */; };
-		21C81E471D9C945E000D9BAF /* AttributeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C81E441D9C945E000D9BAF /* AttributeType.swift */; };
-		21C81E491D9C9548000D9BAF /* Address.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C81E481D9C9548000D9BAF /* Address.swift */; };
 		21D462041D23FD0A00CB8C8E /* CartTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D462031D23FD0A00CB8C8E /* CartTests.swift */; };
 		21F26D8F1CD0B8B100DFFEB8 /* XCTestCase+Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F26D8E1CD0B8B100DFFEB8 /* XCTestCase+Configuration.swift */; };
 		5282479BE674314D916A0355 /* Pods_Commercetools.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A456D0DAC39F1D37C1FEDB0 /* Pods_Commercetools.framework */; };
@@ -75,34 +117,91 @@
 
 /* Begin PBXFileReference section */
 		1C0889E723DFCA9C32A525D9 /* Pods_CommercetoolsTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CommercetoolsTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		210BE01056F4E128E522C7E7 /* ShippingRate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShippingRate.swift; sourceTree = "<group>"; };
+		210BE03BD07142FA05844846 /* Attribute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Attribute.swift; sourceTree = "<group>"; };
+		210BE05E98486D4447F83690 /* Money.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Money.swift; sourceTree = "<group>"; };
+		210BE0C38CA3F227B1FEF646 /* Payment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Payment.swift; sourceTree = "<group>"; };
+		210BE0C5257F3269595A8617 /* TaxRate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaxRate.swift; sourceTree = "<group>"; };
 		210BE12054F8D0CB0147CBD9 /* ByIdEndpoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ByIdEndpoint.swift; sourceTree = "<group>"; };
+		210BE18DB940A25ADCA2D301 /* TransactionState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionState.swift; sourceTree = "<group>"; };
+		210BE1D33B6104781CA48829 /* TaxCategory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaxCategory.swift; sourceTree = "<group>"; };
+		210BE1E119ACC6A0229139F6 /* SubRate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubRate.swift; sourceTree = "<group>"; };
+		210BE2531CF6F3C1B345E202 /* CustomLineItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomLineItem.swift; sourceTree = "<group>"; };
 		210BE258C80D22ECAA4660A4 /* ProductType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductType.swift; sourceTree = "<group>"; };
+		210BE2853D7DC183E939471B /* DiscountedLineItemPortion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiscountedLineItemPortion.swift; sourceTree = "<group>"; };
+		210BE2A14BC8A54E6A803EB7 /* DiscountCodeInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiscountCodeInfo.swift; sourceTree = "<group>"; };
+		210BE2D19F484AAD355FFAD4 /* Price.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Price.swift; sourceTree = "<group>"; };
 		210BE2D37FC5D53E1528CEBB /* Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
+		210BE30D704D107A518AC4E9 /* LineItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LineItem.swift; sourceTree = "<group>"; };
+		210BE340163DD6D9479ECA94 /* ItemState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ItemState.swift; sourceTree = "<group>"; };
 		210BE36824D8A23C8CFDB13F /* Config.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		210BE3AEF096B27E48F86A4B /* Cart.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cart.swift; sourceTree = "<group>"; };
+		210BE3B8176821E9358D02D2 /* Transaction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Transaction.swift; sourceTree = "<group>"; };
+		210BE3E01399DE690C9E29F3 /* PaymentInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaymentInfo.swift; sourceTree = "<group>"; };
+		210BE45EE3CF66D8CDC3C635 /* ShippingMethod.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShippingMethod.swift; sourceTree = "<group>"; };
 		210BE4751F066B02CE24C3BF /* ActiveCart.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActiveCart.swift; sourceTree = "<group>"; };
 		210BE4DCEEE2B368FC013FF0 /* Order.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Order.swift; sourceTree = "<group>"; };
+		210BE4E18D39AAC4D717A979 /* Location.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Location.swift; sourceTree = "<group>"; };
+		210BE527FE929BB31797E084 /* PaymentStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaymentStatus.swift; sourceTree = "<group>"; };
+		210BE529D940FF5B7B41090A /* DiscountedLineItemPrice.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiscountedLineItemPrice.swift; sourceTree = "<group>"; };
 		210BE57833F74D2656716AF8 /* CTError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CTError.swift; sourceTree = "<group>"; };
 		210BE57902D25B9BD0342A69 /* Customer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Customer.swift; sourceTree = "<group>"; };
+		210BE58B423D68B439480AF2 /* CartDiscount.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CartDiscount.swift; sourceTree = "<group>"; };
+		210BE59473D4429CE5E4C1CD /* DiscountCode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiscountCode.swift; sourceTree = "<group>"; };
+		210BE5C490469B5F6E9A6F48 /* DiscountedLineItemPriceForQuantity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiscountedLineItemPriceForQuantity.swift; sourceTree = "<group>"; };
+		210BE5C8BF973677F5E53C98 /* Delivery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Delivery.swift; sourceTree = "<group>"; };
+		210BE5FE86DEEF15BBB326B9 /* AttributeType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributeType.swift; sourceTree = "<group>"; };
+		210BE6287015A18476C288FA /* InventoryMode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InventoryMode.swift; sourceTree = "<group>"; };
+		210BE67367EDD97EE6BD0EBE /* ProductVariantAvailability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductVariantAvailability.swift; sourceTree = "<group>"; };
 		210BE69087D43E8630A27203 /* AuthManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
 		210BE6AA937472A9A87BA7CF /* ByKeyEndpointTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ByKeyEndpointTests.swift; sourceTree = "<group>"; };
+		210BE6B1EEF59FD0DAC2E8E9 /* CartDiscountValue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CartDiscountValue.swift; sourceTree = "<group>"; };
 		210BE6DAAB250113B9FC53CF /* ByKeyEndpoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ByKeyEndpoint.swift; sourceTree = "<group>"; };
+		210BE713166F1B45AFDDAD45 /* Address.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Address.swift; sourceTree = "<group>"; };
 		210BE75EF663DC6979FE0FCF /* QueryEndpoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueryEndpoint.swift; sourceTree = "<group>"; };
 		210BE774D4E1BC8C46FE54F1 /* QueryEndpointTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueryEndpointTests.swift; sourceTree = "<group>"; };
+		210BE77717A599BDC7139F3F /* Image.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Image.swift; sourceTree = "<group>"; };
+		210BE7807F6B8C042C8F6F69 /* DeliveryItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeliveryItem.swift; sourceTree = "<group>"; };
 		210BE7EF595235524206718F /* Commercetools.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Commercetools.swift; sourceTree = "<group>"; };
 		210BE80A6E99FC9F608AC3A6 /* DeleteEndpoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeleteEndpoint.swift; sourceTree = "<group>"; };
+		210BE87AB39F8703A7C83831 /* CartDiscountTarget.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CartDiscountTarget.swift; sourceTree = "<group>"; };
+		210BE8BF8309FF6BAB244FC8 /* TrackingData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackingData.swift; sourceTree = "<group>"; };
+		210BE9449BBF4A8DD0B7B09E /* StateRole.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StateRole.swift; sourceTree = "<group>"; };
+		210BE97FE140122183D67ED7 /* CustomerGroup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomerGroup.swift; sourceTree = "<group>"; };
+		210BE9A116673BA1D5E758FF /* Reference.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Reference.swift; sourceTree = "<group>"; };
+		210BEA38F1A3754058F16FDC /* TaxMode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaxMode.swift; sourceTree = "<group>"; };
+		210BEA79B4FA8CDFF3BA78D5 /* DiscountCodeState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiscountCodeState.swift; sourceTree = "<group>"; };
 		210BEA9FB39CC0B4C382E087 /* Endpoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Endpoint.swift; sourceTree = "<group>"; };
+		210BEAABCBDF178FC0D01D3C /* Channel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Channel.swift; sourceTree = "<group>"; };
 		210BEAADF7135452064FD935 /* Log.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
 		210BEB5FEB721BD118FB29D5 /* UpdateByKeyEndpoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UpdateByKeyEndpoint.swift; sourceTree = "<group>"; };
 		210BEB9F8FEDA82BE1A8C60E /* ProductProjection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductProjection.swift; sourceTree = "<group>"; };
+		210BEBB7A0793F288DF820AA /* ProductVariant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductVariant.swift; sourceTree = "<group>"; };
 		210BEBE03DA0A2EEB49D3DA2 /* DeleteEndpointTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeleteEndpointTests.swift; sourceTree = "<group>"; };
+		210BEBE060BABF8FDD751F43 /* StateType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StateType.swift; sourceTree = "<group>"; };
+		210BEBF406AB4C5BABCAA58B /* PaymentMethodInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaymentMethodInfo.swift; sourceTree = "<group>"; };
 		210BEC0502A7456AB50DC1B1 /* UpdateByKeyEndpointTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UpdateByKeyEndpointTests.swift; sourceTree = "<group>"; };
+		210BEC5B0CA7B043DA3B6C93 /* TaxedPrice.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaxedPrice.swift; sourceTree = "<group>"; };
 		210BEC9E16C430A31F462309 /* UpdateEndpoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UpdateEndpoint.swift; sourceTree = "<group>"; };
+		210BED5F353303DA7B5B783C /* DiscountedPrice.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiscountedPrice.swift; sourceTree = "<group>"; };
+		210BED7B56DBE214863A4ABB /* State.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = State.swift; sourceTree = "<group>"; };
+		210BED939684FBFABFD06355 /* ReviewRatingStatistics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReviewRatingStatistics.swift; sourceTree = "<group>"; };
+		210BED9CFCFD1221B5DC110C /* TaxedItemPrice.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaxedItemPrice.swift; sourceTree = "<group>"; };
+		210BEDA866AE8388BED6DB32 /* ChannelRole.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChannelRole.swift; sourceTree = "<group>"; };
+		210BEDDD266CE08EBEFEC1E8 /* LineItemPriceMode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LineItemPriceMode.swift; sourceTree = "<group>"; };
+		210BEE448CC3B247AA1F8350 /* ParcelMeasurements.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParcelMeasurements.swift; sourceTree = "<group>"; };
+		210BEEA309294925C55F36D8 /* Parcel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Parcel.swift; sourceTree = "<group>"; };
 		210BEEDD69E4AAC50AE994C4 /* Category.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Category.swift; sourceTree = "<group>"; };
+		210BEEEFC28FE8E382F62D64 /* ShippingInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShippingInfo.swift; sourceTree = "<group>"; };
 		210BEEF193D03D0E260EF170 /* UpdateEndpointTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UpdateEndpointTests.swift; sourceTree = "<group>"; };
+		210BEF0359B7130545B6C576 /* CartState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CartState.swift; sourceTree = "<group>"; };
+		210BEF046B415B548D289A3F /* TransactionType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionType.swift; sourceTree = "<group>"; };
 		210BEF34FFFADD720A136729 /* CreateEndpoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CreateEndpoint.swift; sourceTree = "<group>"; };
+		210BEF391627F9DE1730CC16 /* Zone.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Zone.swift; sourceTree = "<group>"; };
 		210BEF4B389CAF21987D0F00 /* TokenStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenStore.swift; sourceTree = "<group>"; };
 		210BEF918E99658EE26EA2EE /* CreateEndpointTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CreateEndpointTests.swift; sourceTree = "<group>"; };
+		210BEFA52DA4F82DDAA860C2 /* AttributeDefinition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributeDefinition.swift; sourceTree = "<group>"; };
+		210BEFDB770916BB1DDCEB4E /* ZoneRate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZoneRate.swift; sourceTree = "<group>"; };
 		210BEFF22F11C1A9EE22C1E1 /* ByIdEndpointTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ByIdEndpointTests.swift; sourceTree = "<group>"; };
 		2111C3F41CD7831D00B2C082 /* CustomerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomerTests.swift; sourceTree = "<group>"; };
 		211B59361CC77C7200246522 /* CommercetoolsTestConfig.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = CommercetoolsTestConfig.plist; sourceTree = "<group>"; };
@@ -113,21 +212,6 @@
 		21C653421CBE6291008E84B2 /* Commercetools.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Commercetools.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		21C6534C1CBE6292008E84B2 /* CommercetoolsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CommercetoolsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		21C653511CBE6292008E84B2 /* AuthManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManagerTests.swift; sourceTree = "<group>"; };
-		21C81E2C1D9C916E000D9BAF /* LineItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LineItem.swift; path = Models/LineItem.swift; sourceTree = "<group>"; };
-		21C81E2E1D9C9228000D9BAF /* DiscountedLineItemPrice.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DiscountedLineItemPrice.swift; path = Models/DiscountedLineItemPrice.swift; sourceTree = "<group>"; };
-		21C81E2F1D9C9228000D9BAF /* DiscountedLineItemPriceForQuantity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DiscountedLineItemPriceForQuantity.swift; path = Models/DiscountedLineItemPriceForQuantity.swift; sourceTree = "<group>"; };
-		21C81E301D9C9228000D9BAF /* DiscountedPrice.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DiscountedPrice.swift; path = Models/DiscountedPrice.swift; sourceTree = "<group>"; };
-		21C81E311D9C9228000D9BAF /* Image.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Image.swift; path = Models/Image.swift; sourceTree = "<group>"; };
-		21C81E321D9C9228000D9BAF /* Money.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Money.swift; path = Models/Money.swift; sourceTree = "<group>"; };
-		21C81E331D9C9228000D9BAF /* Price.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Price.swift; path = Models/Price.swift; sourceTree = "<group>"; };
-		21C81E341D9C9228000D9BAF /* ProductVariant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ProductVariant.swift; path = Models/ProductVariant.swift; sourceTree = "<group>"; };
-		21C81E351D9C9228000D9BAF /* ProductVariantAvailability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ProductVariantAvailability.swift; path = Models/ProductVariantAvailability.swift; sourceTree = "<group>"; };
-		21C81E361D9C9228000D9BAF /* TaxedPrice.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TaxedPrice.swift; path = Models/TaxedPrice.swift; sourceTree = "<group>"; };
-		21C81E401D9C92FB000D9BAF /* Channel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Channel.swift; path = Models/Channel.swift; sourceTree = "<group>"; };
-		21C81E421D9C945E000D9BAF /* Attribute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Attribute.swift; path = Models/Attribute.swift; sourceTree = "<group>"; };
-		21C81E431D9C945E000D9BAF /* AttributeDefinition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AttributeDefinition.swift; path = Models/AttributeDefinition.swift; sourceTree = "<group>"; };
-		21C81E441D9C945E000D9BAF /* AttributeType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AttributeType.swift; path = Models/AttributeType.swift; sourceTree = "<group>"; };
-		21C81E481D9C9548000D9BAF /* Address.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Address.swift; path = Models/Address.swift; sourceTree = "<group>"; };
 		21D462031D23FD0A00CB8C8E /* CartTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CartTests.swift; sourceTree = "<group>"; };
 		21F26D8E1CD0B8B100DFFEB8 /* XCTestCase+Configuration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Configuration.swift"; sourceTree = "<group>"; };
 		29502A041BA37E6BD22C3C21 /* Pods-Commercetools.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Commercetools.release.xcconfig"; path = "Pods/Target Support Files/Pods-Commercetools/Pods-Commercetools.release.xcconfig"; sourceTree = "<group>"; };
@@ -189,6 +273,70 @@
 				210BE4751F066B02CE24C3BF /* ActiveCart.swift */,
 			);
 			path = Endpoints;
+			sourceTree = "<group>";
+		};
+		210BE9386B7024AAED9DDB48 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				210BE2A14BC8A54E6A803EB7 /* DiscountCodeInfo.swift */,
+				210BE5C490469B5F6E9A6F48 /* DiscountedLineItemPriceForQuantity.swift */,
+				210BEBB7A0793F288DF820AA /* ProductVariant.swift */,
+				210BE97FE140122183D67ED7 /* CustomerGroup.swift */,
+				210BEFA52DA4F82DDAA860C2 /* AttributeDefinition.swift */,
+				210BE6287015A18476C288FA /* InventoryMode.swift */,
+				210BEF0359B7130545B6C576 /* CartState.swift */,
+				210BEAABCBDF178FC0D01D3C /* Channel.swift */,
+				210BE67367EDD97EE6BD0EBE /* ProductVariantAvailability.swift */,
+				210BE713166F1B45AFDDAD45 /* Address.swift */,
+				210BEA79B4FA8CDFF3BA78D5 /* DiscountCodeState.swift */,
+				210BE2D19F484AAD355FFAD4 /* Price.swift */,
+				210BED5F353303DA7B5B783C /* DiscountedPrice.swift */,
+				210BE30D704D107A518AC4E9 /* LineItem.swift */,
+				210BE2531CF6F3C1B345E202 /* CustomLineItem.swift */,
+				210BEC5B0CA7B043DA3B6C93 /* TaxedPrice.swift */,
+				210BE05E98486D4447F83690 /* Money.swift */,
+				210BEA38F1A3754058F16FDC /* TaxMode.swift */,
+				210BE59473D4429CE5E4C1CD /* DiscountCode.swift */,
+				210BE529D940FF5B7B41090A /* DiscountedLineItemPrice.swift */,
+				210BE77717A599BDC7139F3F /* Image.swift */,
+				210BEEEFC28FE8E382F62D64 /* ShippingInfo.swift */,
+				210BE03BD07142FA05844846 /* Attribute.swift */,
+				210BE5FE86DEEF15BBB326B9 /* AttributeType.swift */,
+				210BE3E01399DE690C9E29F3 /* PaymentInfo.swift */,
+				210BE9A116673BA1D5E758FF /* Reference.swift */,
+				210BE0C38CA3F227B1FEF646 /* Payment.swift */,
+				210BED9CFCFD1221B5DC110C /* TaxedItemPrice.swift */,
+				210BE340163DD6D9479ECA94 /* ItemState.swift */,
+				210BED7B56DBE214863A4ABB /* State.swift */,
+				210BE0C5257F3269595A8617 /* TaxRate.swift */,
+				210BE1E119ACC6A0229139F6 /* SubRate.swift */,
+				210BED939684FBFABFD06355 /* ReviewRatingStatistics.swift */,
+				210BE2853D7DC183E939471B /* DiscountedLineItemPortion.swift */,
+				210BE58B423D68B439480AF2 /* CartDiscount.swift */,
+				210BE6B1EEF59FD0DAC2E8E9 /* CartDiscountValue.swift */,
+				210BE87AB39F8703A7C83831 /* CartDiscountTarget.swift */,
+				210BEDDD266CE08EBEFEC1E8 /* LineItemPriceMode.swift */,
+				210BE1D33B6104781CA48829 /* TaxCategory.swift */,
+				210BEBF406AB4C5BABCAA58B /* PaymentMethodInfo.swift */,
+				210BE527FE929BB31797E084 /* PaymentStatus.swift */,
+				210BE3B8176821E9358D02D2 /* Transaction.swift */,
+				210BEF046B415B548D289A3F /* TransactionType.swift */,
+				210BE18DB940A25ADCA2D301 /* TransactionState.swift */,
+				210BEDA866AE8388BED6DB32 /* ChannelRole.swift */,
+				210BEBE060BABF8FDD751F43 /* StateType.swift */,
+				210BE9449BBF4A8DD0B7B09E /* StateRole.swift */,
+				210BE01056F4E128E522C7E7 /* ShippingRate.swift */,
+				210BE45EE3CF66D8CDC3C635 /* ShippingMethod.swift */,
+				210BEFDB770916BB1DDCEB4E /* ZoneRate.swift */,
+				210BEF391627F9DE1730CC16 /* Zone.swift */,
+				210BE4E18D39AAC4D717A979 /* Location.swift */,
+				210BE5C8BF973677F5E53C98 /* Delivery.swift */,
+				210BE7807F6B8C042C8F6F69 /* DeliveryItem.swift */,
+				210BEEA309294925C55F36D8 /* Parcel.swift */,
+				210BEE448CC3B247AA1F8350 /* ParcelMeasurements.swift */,
+				210BE8BF8309FF6BAB244FC8 /* TrackingData.swift */,
+			);
+			path = Models;
 			sourceTree = "<group>";
 		};
 		210BEC3C800BFC27FD53DCE3 /* Core */ = {
@@ -267,7 +415,6 @@
 			children = (
 				210BEC3CECE84C25122CFBE3 /* Core */,
 				210BE57E609238C63F1BC032 /* Endpoints */,
-				21C81E2B1D9C90FE000D9BAF /* Models */,
 				210BE7EF595235524206718F /* Commercetools.swift */,
 				210BE36824D8A23C8CFDB13F /* Config.swift */,
 				210BEAADF7135452064FD935 /* Log.swift */,
@@ -276,31 +423,10 @@
 				210BEF4B389CAF21987D0F00 /* TokenStore.swift */,
 				210BE2D37FC5D53E1528CEBB /* Result.swift */,
 				21C6080C1CE00A71001A68A7 /* Supporting Files */,
+				210BE9386B7024AAED9DDB48 /* Models */,
 			);
 			path = Source;
 			sourceTree = SOURCE_ROOT;
-		};
-		21C81E2B1D9C90FE000D9BAF /* Models */ = {
-			isa = PBXGroup;
-			children = (
-				21C81E481D9C9548000D9BAF /* Address.swift */,
-				21C81E421D9C945E000D9BAF /* Attribute.swift */,
-				21C81E431D9C945E000D9BAF /* AttributeDefinition.swift */,
-				21C81E441D9C945E000D9BAF /* AttributeType.swift */,
-				21C81E401D9C92FB000D9BAF /* Channel.swift */,
-				21C81E2E1D9C9228000D9BAF /* DiscountedLineItemPrice.swift */,
-				21C81E2F1D9C9228000D9BAF /* DiscountedLineItemPriceForQuantity.swift */,
-				21C81E301D9C9228000D9BAF /* DiscountedPrice.swift */,
-				21C81E311D9C9228000D9BAF /* Image.swift */,
-				21C81E321D9C9228000D9BAF /* Money.swift */,
-				21C81E331D9C9228000D9BAF /* Price.swift */,
-				21C81E341D9C9228000D9BAF /* ProductVariant.swift */,
-				21C81E351D9C9228000D9BAF /* ProductVariantAvailability.swift */,
-				21C81E361D9C9228000D9BAF /* TaxedPrice.swift */,
-				21C81E2C1D9C916E000D9BAF /* LineItem.swift */,
-			);
-			name = Models;
-			sourceTree = "<group>";
 		};
 		CB1FFB69F4CD60CC05B6E787 /* Pods */ = {
 			isa = PBXGroup;
@@ -508,42 +634,84 @@
 			buildActionMask = 2147483647;
 			files = (
 				210BE0FB35AF665054D028C4 /* Commercetools.swift in Sources */,
-				21C81E3A1D9C9228000D9BAF /* Image.swift in Sources */,
-				21C81E3B1D9C9228000D9BAF /* Money.swift in Sources */,
 				210BEDC4D05E071DA9248E17 /* Config.swift in Sources */,
-				21C81E3E1D9C9228000D9BAF /* ProductVariantAvailability.swift in Sources */,
 				210BE9F03FC6EB74CA205C35 /* Log.swift in Sources */,
-				21C81E391D9C9228000D9BAF /* DiscountedPrice.swift in Sources */,
-				21C81E461D9C945E000D9BAF /* AttributeDefinition.swift in Sources */,
 				210BEE7F0EF61808761BDBB5 /* AuthManager.swift in Sources */,
 				210BE7E502CA456C30566881 /* CTError.swift in Sources */,
 				210BEF7772BC10CA87E61644 /* TokenStore.swift in Sources */,
 				210BEFC6EB3105F2FC9CEDA1 /* Endpoint.swift in Sources */,
 				210BE01F162E3933AA6871EF /* CreateEndpoint.swift in Sources */,
 				210BE40C5DD231FC289ACC9F /* ByIdEndpoint.swift in Sources */,
-				21C81E411D9C92FB000D9BAF /* Channel.swift in Sources */,
 				210BED47512A21301ACEFE86 /* Result.swift in Sources */,
-				21C81E3D1D9C9228000D9BAF /* ProductVariant.swift in Sources */,
 				210BE3925983FE6D33226BD1 /* DeleteEndpoint.swift in Sources */,
 				210BE2F771FF1894369D01B5 /* UpdateEndpoint.swift in Sources */,
 				210BE35D4CAA2F56F2E62062 /* QueryEndpoint.swift in Sources */,
-				21C81E491D9C9548000D9BAF /* Address.swift in Sources */,
 				210BE2CBF45130959D9E2843 /* ByKeyEndpoint.swift in Sources */,
 				210BE035746D461EF781B601 /* UpdateByKeyEndpoint.swift in Sources */,
-				21C81E3F1D9C9228000D9BAF /* TaxedPrice.swift in Sources */,
 				210BE80CB72C73E5D330AA32 /* Cart.swift in Sources */,
-				21C81E471D9C945E000D9BAF /* AttributeType.swift in Sources */,
 				210BE317383AF01BE274933A /* Customer.swift in Sources */,
-				21C81E2D1D9C916E000D9BAF /* LineItem.swift in Sources */,
 				210BE6C3063D6C460F6D8601 /* Order.swift in Sources */,
 				210BE30354065747CA48F92C /* ProductProjection.swift in Sources */,
-				21C81E381D9C9228000D9BAF /* DiscountedLineItemPriceForQuantity.swift in Sources */,
-				21C81E371D9C9228000D9BAF /* DiscountedLineItemPrice.swift in Sources */,
 				210BE46ADE08AB809FFB22DD /* ProductType.swift in Sources */,
-				21C81E3C1D9C9228000D9BAF /* Price.swift in Sources */,
 				210BE66645DA622BEE3ED25A /* Category.swift in Sources */,
-				21C81E451D9C945E000D9BAF /* Attribute.swift in Sources */,
 				210BE9B7A4D7D1BE572FE27D /* ActiveCart.swift in Sources */,
+				210BE5FC5FD05550C134289E /* DiscountCodeInfo.swift in Sources */,
+				210BE37BB47291253613E607 /* DiscountedLineItemPriceForQuantity.swift in Sources */,
+				210BED7587E729A08770D802 /* ProductVariant.swift in Sources */,
+				210BE1714C5D46C856FD5E42 /* CustomerGroup.swift in Sources */,
+				210BE5F129026F44D837CCED /* AttributeDefinition.swift in Sources */,
+				210BE1E69F54FD25B4321EF5 /* InventoryMode.swift in Sources */,
+				210BE266E1578CD09A4B5D7E /* CartState.swift in Sources */,
+				210BEEA91E37EFD61DD9FED0 /* Channel.swift in Sources */,
+				210BE38E327F9506FC0A9998 /* ProductVariantAvailability.swift in Sources */,
+				210BEE339332A06E80D3C098 /* Address.swift in Sources */,
+				210BE2F3F552DCAB853DC30E /* DiscountCodeState.swift in Sources */,
+				210BEEAB90E24376A22ADF19 /* Price.swift in Sources */,
+				210BE37EBA33C93099FA8827 /* DiscountedPrice.swift in Sources */,
+				210BEA074EAD575F57C3A5C5 /* LineItem.swift in Sources */,
+				210BE86F7775A5AF26BF088B /* CustomLineItem.swift in Sources */,
+				210BEE5E101C0C9FBEE2631E /* TaxedPrice.swift in Sources */,
+				210BEEB01644FDD20B770E53 /* Money.swift in Sources */,
+				210BEBF11EC76D94CCF45358 /* TaxMode.swift in Sources */,
+				210BEFC77DAD1E64B738E641 /* DiscountCode.swift in Sources */,
+				210BE374F7A32C4D7BA99BFE /* DiscountedLineItemPrice.swift in Sources */,
+				210BE536AB7ED419A07D88D8 /* Image.swift in Sources */,
+				210BE6F3C54B989B55F7BFB5 /* ShippingInfo.swift in Sources */,
+				210BE6A79E9699D396DF5EE0 /* Attribute.swift in Sources */,
+				210BE9C4A49D0522D83F49EB /* AttributeType.swift in Sources */,
+				210BE0765D49BC5CEC7BC341 /* PaymentInfo.swift in Sources */,
+				210BE61C136463F5568A25CC /* Reference.swift in Sources */,
+				210BE42B33BAC3F1A224846C /* Payment.swift in Sources */,
+				210BE577E4E65FDD58C68840 /* TaxedItemPrice.swift in Sources */,
+				210BE1237FACC3260C5BF4BB /* ItemState.swift in Sources */,
+				210BE2C718C9460DB6549702 /* State.swift in Sources */,
+				210BE7C6DE425E7C3D406D86 /* TaxRate.swift in Sources */,
+				210BE683AE4D4FA463B8354D /* SubRate.swift in Sources */,
+				210BED8D87FC3DC6108ECCE1 /* ReviewRatingStatistics.swift in Sources */,
+				210BE80F25E51727BADFF914 /* DiscountedLineItemPortion.swift in Sources */,
+				210BEFD6D276BC91DFE3F4EE /* CartDiscount.swift in Sources */,
+				210BE54F79BF27BFFCF60998 /* CartDiscountValue.swift in Sources */,
+				210BEE20EDE0493C6171F206 /* CartDiscountTarget.swift in Sources */,
+				210BE13FBA1E33EE1FF7103D /* LineItemPriceMode.swift in Sources */,
+				210BE3058C8068A0C2650C4B /* TaxCategory.swift in Sources */,
+				210BEB5CFFA25C9B2F702751 /* PaymentMethodInfo.swift in Sources */,
+				210BEEF7F6C9AE602CCA443B /* PaymentStatus.swift in Sources */,
+				210BE33C8A2E3C9591C5E23D /* Transaction.swift in Sources */,
+				210BE886787B66312EC6FEDC /* TransactionType.swift in Sources */,
+				210BE53DF2703D96FFF2919F /* TransactionState.swift in Sources */,
+				210BE576BDE9EF6C87248983 /* ChannelRole.swift in Sources */,
+				210BE598AD2157B642AA3A72 /* StateType.swift in Sources */,
+				210BEA1170C392AA36907B63 /* StateRole.swift in Sources */,
+				210BECC47AA7F5A62607A33F /* ShippingRate.swift in Sources */,
+				210BEC69714EE2F07B77F5A5 /* ShippingMethod.swift in Sources */,
+				210BE0454C553693B732F5EA /* ZoneRate.swift in Sources */,
+				210BEA9A3DDB3216E94A6152 /* Zone.swift in Sources */,
+				210BEAF3789CFF3898152D79 /* Location.swift in Sources */,
+				210BE1B83F1A1B1CCE1A10BA /* Delivery.swift in Sources */,
+				210BEE1DD44E871B71E628D3 /* DeliveryItem.swift in Sources */,
+				210BE3B4DBAC4A11709B6556 /* Parcel.swift in Sources */,
+				210BEC975581F978049C5C76 /* ParcelMeasurements.swift in Sources */,
+				210BE971C2751BFAF5B11D8A /* TrackingData.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Commercetools.xcodeproj/project.pbxproj
+++ b/Commercetools.xcodeproj/project.pbxproj
@@ -38,13 +38,26 @@
 		210BEFC6EB3105F2FC9CEDA1 /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEA9FB39CC0B4C382E087 /* Endpoint.swift */; };
 		2111C3F51CD7831D00B2C082 /* CustomerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2111C3F41CD7831D00B2C082 /* CustomerTests.swift */; };
 		211B59371CC77C7200246522 /* CommercetoolsTestConfig.plist in Resources */ = {isa = PBXBuildFile; fileRef = 211B59361CC77C7200246522 /* CommercetoolsTestConfig.plist */; };
-		211B593A1CC782B400246522 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 211B59391CC782B400246522 /* Info.plist */; };
 		213398191CDB8BB2003248BD /* ProductProjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213398181CDB8BB2003248BD /* ProductProjectionTests.swift */; };
 		21766DD87D8671A3760DFB32 /* Pods_CommercetoolsTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1C0889E723DFCA9C32A525D9 /* Pods_CommercetoolsTests.framework */; };
 		21C6080A1CE006EE001A68A7 /* Commercetools.h in Headers */ = {isa = PBXBuildFile; fileRef = 21C608081CE006EE001A68A7 /* Commercetools.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		21C6080B1CE006EE001A68A7 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 21C608091CE006EE001A68A7 /* Info.plist */; };
 		21C6534D1CBE6292008E84B2 /* Commercetools.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 21C653421CBE6291008E84B2 /* Commercetools.framework */; };
 		21C653521CBE6292008E84B2 /* AuthManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C653511CBE6292008E84B2 /* AuthManagerTests.swift */; };
+		21C81E2D1D9C916E000D9BAF /* LineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C81E2C1D9C916E000D9BAF /* LineItem.swift */; };
+		21C81E371D9C9228000D9BAF /* DiscountedLineItemPrice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C81E2E1D9C9228000D9BAF /* DiscountedLineItemPrice.swift */; };
+		21C81E381D9C9228000D9BAF /* DiscountedLineItemPriceForQuantity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C81E2F1D9C9228000D9BAF /* DiscountedLineItemPriceForQuantity.swift */; };
+		21C81E391D9C9228000D9BAF /* DiscountedPrice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C81E301D9C9228000D9BAF /* DiscountedPrice.swift */; };
+		21C81E3A1D9C9228000D9BAF /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C81E311D9C9228000D9BAF /* Image.swift */; };
+		21C81E3B1D9C9228000D9BAF /* Money.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C81E321D9C9228000D9BAF /* Money.swift */; };
+		21C81E3C1D9C9228000D9BAF /* Price.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C81E331D9C9228000D9BAF /* Price.swift */; };
+		21C81E3D1D9C9228000D9BAF /* ProductVariant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C81E341D9C9228000D9BAF /* ProductVariant.swift */; };
+		21C81E3E1D9C9228000D9BAF /* ProductVariantAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C81E351D9C9228000D9BAF /* ProductVariantAvailability.swift */; };
+		21C81E3F1D9C9228000D9BAF /* TaxedPrice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C81E361D9C9228000D9BAF /* TaxedPrice.swift */; };
+		21C81E411D9C92FB000D9BAF /* Channel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C81E401D9C92FB000D9BAF /* Channel.swift */; };
+		21C81E451D9C945E000D9BAF /* Attribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C81E421D9C945E000D9BAF /* Attribute.swift */; };
+		21C81E461D9C945E000D9BAF /* AttributeDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C81E431D9C945E000D9BAF /* AttributeDefinition.swift */; };
+		21C81E471D9C945E000D9BAF /* AttributeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C81E441D9C945E000D9BAF /* AttributeType.swift */; };
+		21C81E491D9C9548000D9BAF /* Address.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C81E481D9C9548000D9BAF /* Address.swift */; };
 		21D462041D23FD0A00CB8C8E /* CartTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D462031D23FD0A00CB8C8E /* CartTests.swift */; };
 		21F26D8F1CD0B8B100DFFEB8 /* XCTestCase+Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F26D8E1CD0B8B100DFFEB8 /* XCTestCase+Configuration.swift */; };
 		5282479BE674314D916A0355 /* Pods_Commercetools.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A456D0DAC39F1D37C1FEDB0 /* Pods_Commercetools.framework */; };
@@ -100,6 +113,21 @@
 		21C653421CBE6291008E84B2 /* Commercetools.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Commercetools.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		21C6534C1CBE6292008E84B2 /* CommercetoolsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CommercetoolsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		21C653511CBE6292008E84B2 /* AuthManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManagerTests.swift; sourceTree = "<group>"; };
+		21C81E2C1D9C916E000D9BAF /* LineItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LineItem.swift; path = Models/LineItem.swift; sourceTree = "<group>"; };
+		21C81E2E1D9C9228000D9BAF /* DiscountedLineItemPrice.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DiscountedLineItemPrice.swift; path = Models/DiscountedLineItemPrice.swift; sourceTree = "<group>"; };
+		21C81E2F1D9C9228000D9BAF /* DiscountedLineItemPriceForQuantity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DiscountedLineItemPriceForQuantity.swift; path = Models/DiscountedLineItemPriceForQuantity.swift; sourceTree = "<group>"; };
+		21C81E301D9C9228000D9BAF /* DiscountedPrice.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DiscountedPrice.swift; path = Models/DiscountedPrice.swift; sourceTree = "<group>"; };
+		21C81E311D9C9228000D9BAF /* Image.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Image.swift; path = Models/Image.swift; sourceTree = "<group>"; };
+		21C81E321D9C9228000D9BAF /* Money.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Money.swift; path = Models/Money.swift; sourceTree = "<group>"; };
+		21C81E331D9C9228000D9BAF /* Price.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Price.swift; path = Models/Price.swift; sourceTree = "<group>"; };
+		21C81E341D9C9228000D9BAF /* ProductVariant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ProductVariant.swift; path = Models/ProductVariant.swift; sourceTree = "<group>"; };
+		21C81E351D9C9228000D9BAF /* ProductVariantAvailability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ProductVariantAvailability.swift; path = Models/ProductVariantAvailability.swift; sourceTree = "<group>"; };
+		21C81E361D9C9228000D9BAF /* TaxedPrice.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TaxedPrice.swift; path = Models/TaxedPrice.swift; sourceTree = "<group>"; };
+		21C81E401D9C92FB000D9BAF /* Channel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Channel.swift; path = Models/Channel.swift; sourceTree = "<group>"; };
+		21C81E421D9C945E000D9BAF /* Attribute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Attribute.swift; path = Models/Attribute.swift; sourceTree = "<group>"; };
+		21C81E431D9C945E000D9BAF /* AttributeDefinition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AttributeDefinition.swift; path = Models/AttributeDefinition.swift; sourceTree = "<group>"; };
+		21C81E441D9C945E000D9BAF /* AttributeType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AttributeType.swift; path = Models/AttributeType.swift; sourceTree = "<group>"; };
+		21C81E481D9C9548000D9BAF /* Address.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Address.swift; path = Models/Address.swift; sourceTree = "<group>"; };
 		21D462031D23FD0A00CB8C8E /* CartTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CartTests.swift; sourceTree = "<group>"; };
 		21F26D8E1CD0B8B100DFFEB8 /* XCTestCase+Configuration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Configuration.swift"; sourceTree = "<group>"; };
 		29502A041BA37E6BD22C3C21 /* Pods-Commercetools.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Commercetools.release.xcconfig"; path = "Pods/Target Support Files/Pods-Commercetools/Pods-Commercetools.release.xcconfig"; sourceTree = "<group>"; };
@@ -239,6 +267,7 @@
 			children = (
 				210BEC3CECE84C25122CFBE3 /* Core */,
 				210BE57E609238C63F1BC032 /* Endpoints */,
+				21C81E2B1D9C90FE000D9BAF /* Models */,
 				210BE7EF595235524206718F /* Commercetools.swift */,
 				210BE36824D8A23C8CFDB13F /* Config.swift */,
 				210BEAADF7135452064FD935 /* Log.swift */,
@@ -250,6 +279,28 @@
 			);
 			path = Source;
 			sourceTree = SOURCE_ROOT;
+		};
+		21C81E2B1D9C90FE000D9BAF /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				21C81E481D9C9548000D9BAF /* Address.swift */,
+				21C81E421D9C945E000D9BAF /* Attribute.swift */,
+				21C81E431D9C945E000D9BAF /* AttributeDefinition.swift */,
+				21C81E441D9C945E000D9BAF /* AttributeType.swift */,
+				21C81E401D9C92FB000D9BAF /* Channel.swift */,
+				21C81E2E1D9C9228000D9BAF /* DiscountedLineItemPrice.swift */,
+				21C81E2F1D9C9228000D9BAF /* DiscountedLineItemPriceForQuantity.swift */,
+				21C81E301D9C9228000D9BAF /* DiscountedPrice.swift */,
+				21C81E311D9C9228000D9BAF /* Image.swift */,
+				21C81E321D9C9228000D9BAF /* Money.swift */,
+				21C81E331D9C9228000D9BAF /* Price.swift */,
+				21C81E341D9C9228000D9BAF /* ProductVariant.swift */,
+				21C81E351D9C9228000D9BAF /* ProductVariantAvailability.swift */,
+				21C81E361D9C9228000D9BAF /* TaxedPrice.swift */,
+				21C81E2C1D9C916E000D9BAF /* LineItem.swift */,
+			);
+			name = Models;
+			sourceTree = "<group>";
 		};
 		CB1FFB69F4CD60CC05B6E787 /* Pods */ = {
 			isa = PBXGroup;
@@ -280,12 +331,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 21C653561CBE6292008E84B2 /* Build configuration list for PBXNativeTarget "Commercetools" */;
 			buildPhases = (
-				91A200CB2B9196DE02C1C916 /* 📦 Check Pods Manifest.lock */,
+				91A200CB2B9196DE02C1C916 /* [CP] Check Pods Manifest.lock */,
 				21C6533D1CBE6291008E84B2 /* Sources */,
 				21C6533E1CBE6291008E84B2 /* Frameworks */,
 				21C6533F1CBE6291008E84B2 /* Headers */,
 				21C653401CBE6291008E84B2 /* Resources */,
-				01D9270DD1C55426D62BDA6D /* 📦 Copy Pods Resources */,
+				01D9270DD1C55426D62BDA6D /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -300,12 +351,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 21C653591CBE6292008E84B2 /* Build configuration list for PBXNativeTarget "CommercetoolsTests" */;
 			buildPhases = (
-				3D2B4593A97F4CF73AD13F1A /* 📦 Check Pods Manifest.lock */,
+				3D2B4593A97F4CF73AD13F1A /* [CP] Check Pods Manifest.lock */,
 				21C653481CBE6292008E84B2 /* Sources */,
 				21C653491CBE6292008E84B2 /* Frameworks */,
 				21C6534A1CBE6292008E84B2 /* Resources */,
-				DA00A08FA8DBF904EFFE1C95 /* 📦 Embed Pods Frameworks */,
-				2E8EA9486AB94B3360539E76 /* 📦 Copy Pods Resources */,
+				DA00A08FA8DBF904EFFE1C95 /* [CP] Embed Pods Frameworks */,
+				2E8EA9486AB94B3360539E76 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -324,7 +375,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 0730;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = Commercetools;
 				TargetAttributes = {
 					21C653411CBE6291008E84B2 = {
@@ -360,7 +411,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				21C6080B1CE006EE001A68A7 /* Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -368,7 +418,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				211B593A1CC782B400246522 /* Info.plist in Resources */,
 				211B59371CC77C7200246522 /* CommercetoolsTestConfig.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -376,14 +425,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		01D9270DD1C55426D62BDA6D /* 📦 Copy Pods Resources */ = {
+		01D9270DD1C55426D62BDA6D /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -391,14 +440,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Commercetools/Pods-Commercetools-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		2E8EA9486AB94B3360539E76 /* 📦 Copy Pods Resources */ = {
+		2E8EA9486AB94B3360539E76 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -406,44 +455,44 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-CommercetoolsTests/Pods-CommercetoolsTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		3D2B4593A97F4CF73AD13F1A /* 📦 Check Pods Manifest.lock */ = {
+		3D2B4593A97F4CF73AD13F1A /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		91A200CB2B9196DE02C1C916 /* 📦 Check Pods Manifest.lock */ = {
+		91A200CB2B9196DE02C1C916 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		DA00A08FA8DBF904EFFE1C95 /* 📦 Embed Pods Frameworks */ = {
+		DA00A08FA8DBF904EFFE1C95 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Embed Pods Frameworks";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -459,26 +508,41 @@
 			buildActionMask = 2147483647;
 			files = (
 				210BE0FB35AF665054D028C4 /* Commercetools.swift in Sources */,
+				21C81E3A1D9C9228000D9BAF /* Image.swift in Sources */,
+				21C81E3B1D9C9228000D9BAF /* Money.swift in Sources */,
 				210BEDC4D05E071DA9248E17 /* Config.swift in Sources */,
+				21C81E3E1D9C9228000D9BAF /* ProductVariantAvailability.swift in Sources */,
 				210BE9F03FC6EB74CA205C35 /* Log.swift in Sources */,
+				21C81E391D9C9228000D9BAF /* DiscountedPrice.swift in Sources */,
+				21C81E461D9C945E000D9BAF /* AttributeDefinition.swift in Sources */,
 				210BEE7F0EF61808761BDBB5 /* AuthManager.swift in Sources */,
 				210BE7E502CA456C30566881 /* CTError.swift in Sources */,
 				210BEF7772BC10CA87E61644 /* TokenStore.swift in Sources */,
 				210BEFC6EB3105F2FC9CEDA1 /* Endpoint.swift in Sources */,
 				210BE01F162E3933AA6871EF /* CreateEndpoint.swift in Sources */,
 				210BE40C5DD231FC289ACC9F /* ByIdEndpoint.swift in Sources */,
+				21C81E411D9C92FB000D9BAF /* Channel.swift in Sources */,
 				210BED47512A21301ACEFE86 /* Result.swift in Sources */,
+				21C81E3D1D9C9228000D9BAF /* ProductVariant.swift in Sources */,
 				210BE3925983FE6D33226BD1 /* DeleteEndpoint.swift in Sources */,
 				210BE2F771FF1894369D01B5 /* UpdateEndpoint.swift in Sources */,
 				210BE35D4CAA2F56F2E62062 /* QueryEndpoint.swift in Sources */,
+				21C81E491D9C9548000D9BAF /* Address.swift in Sources */,
 				210BE2CBF45130959D9E2843 /* ByKeyEndpoint.swift in Sources */,
 				210BE035746D461EF781B601 /* UpdateByKeyEndpoint.swift in Sources */,
+				21C81E3F1D9C9228000D9BAF /* TaxedPrice.swift in Sources */,
 				210BE80CB72C73E5D330AA32 /* Cart.swift in Sources */,
+				21C81E471D9C945E000D9BAF /* AttributeType.swift in Sources */,
 				210BE317383AF01BE274933A /* Customer.swift in Sources */,
+				21C81E2D1D9C916E000D9BAF /* LineItem.swift in Sources */,
 				210BE6C3063D6C460F6D8601 /* Order.swift in Sources */,
 				210BE30354065747CA48F92C /* ProductProjection.swift in Sources */,
+				21C81E381D9C9228000D9BAF /* DiscountedLineItemPriceForQuantity.swift in Sources */,
+				21C81E371D9C9228000D9BAF /* DiscountedLineItemPrice.swift in Sources */,
 				210BE46ADE08AB809FFB22DD /* ProductType.swift in Sources */,
+				21C81E3C1D9C9228000D9BAF /* Price.swift in Sources */,
 				210BE66645DA622BEE3ED25A /* Category.swift in Sources */,
+				21C81E451D9C945E000D9BAF /* Attribute.swift in Sources */,
 				210BE9B7A4D7D1BE572FE27D /* ActiveCart.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -527,8 +591,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -576,8 +642,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -597,6 +665,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -608,6 +677,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = B4BC5B13A5FAE631F09B678E /* Pods-Commercetools.debug.xcconfig */;
 			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -626,6 +696,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 29502A041BA37E6BD22C3C21 /* Pods-Commercetools.release.xcconfig */;
 			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -644,6 +715,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9C0B9BA2818AD6700B1510E5 /* Pods-CommercetoolsTests.debug.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.commercetools.sdk.jvm.ios.CommercetoolsTests;
@@ -656,6 +728,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A0EDB697995DF8E6B98E3F51 /* Pods-CommercetoolsTests.release.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.commercetools.sdk.jvm.ios.CommercetoolsTests;

--- a/Commercetools.xcodeproj/xcshareddata/xcschemes/Commercetools.xcscheme
+++ b/Commercetools.xcodeproj/xcshareddata/xcschemes/Commercetools.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Podfile
+++ b/Podfile
@@ -1,10 +1,15 @@
 platform :ios, '9.0'
 use_frameworks!
 
-target 'Commercetools' do
+def common_pods
     pod 'Alamofire', '~> 4.0'
+    pod 'ObjectMapper', '~> 2.0'
+end
+
+target 'Commercetools' do
+    common_pods
 end
 
 target 'CommercetoolsTests' do
-    pod 'Alamofire', '~> 4.0'
+    common_pods
 end

--- a/Source/Core/ByIdEndpoint.swift
+++ b/Source/Core/ByIdEndpoint.swift
@@ -17,23 +17,43 @@ public protocol ByIdEndpoint: Endpoint {
 
         - parameter id:                       Unique ID of the object to be retrieved.
         - parameter expansion:                An optional array of expansion property names.
-        - parameter result:                   The code to be executed after processing the response.
+        - parameter result:                   The code to be executed after processing the response, providing model
+                                              instance in case of a successful result.
     */
-    static func byId(_ id: String, expansion: [String]?, result: @escaping (Result<[String: Any]>) -> Void)
+    static func byId(_ id: String, expansion: [String]?, result: @escaping (Result<ResponseType>) -> Void)
+    
+    /**
+         Retrieves an object by UUID at the endpoint specified with `path` value.
+     
+         - parameter id:                       Unique ID of the object to be retrieved.
+         - parameter expansion:                An optional array of expansion property names.
+         - parameter dictionaryResult:         The code to be executed after processing the response, containing result
+                                               in dictionary format in case of a success.
+     */
+    static func byId(_ id: String, expansion: [String]?, dictionaryResult: @escaping (Result<[String: Any]>) -> Void)
 
 }
 
 public extension ByIdEndpoint {
-
-    static func byId(_ id: String, expansion: [String]? = nil, result: @escaping (Result<[String: Any]>) -> Void) {
-
+    
+    static func byId(_ id: String, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
+        byId(id, expansion: expansion, result: result, completionHandler: { response in
+            handleResponse(response, result: result)
+        })
+    }
+    
+    static func byId(_ id: String, expansion: [String]? = nil, dictionaryResult: @escaping (Result<[String: Any]>) -> Void) {
+        byId(id, expansion: expansion, result: dictionaryResult, completionHandler: { response in
+            handleResponse(response, result: dictionaryResult)
+        })
+    }
+    
+    private static func byId<T>(_ id: String, expansion: [String]? = nil, result: @escaping (Result<T>) -> Void, completionHandler: @escaping (DataResponse<Any>) -> Void) {
         requestWithTokenAndPath(result, { token, path in
             let fullPath = pathWithExpansion(path + id, expansion: expansion)
-
+            
             Alamofire.request(fullPath, parameters: nil, encoding: JSONEncoding.default, headers: self.headers(token))
-            .responseJSON(queue: DispatchQueue.global(), completionHandler: { response in
-                handleResponse(response, result: result)
-            })
+            .responseJSON(queue: DispatchQueue.global(), completionHandler: completionHandler)
         })
     }
 }

--- a/Source/Core/ByIdEndpoint.swift
+++ b/Source/Core/ByIdEndpoint.swift
@@ -21,39 +21,19 @@ public protocol ByIdEndpoint: Endpoint {
                                               instance in case of a successful result.
     */
     static func byId(_ id: String, expansion: [String]?, result: @escaping (Result<ResponseType>) -> Void)
-    
-    /**
-         Retrieves an object by UUID at the endpoint specified with `path` value.
-     
-         - parameter id:                       Unique ID of the object to be retrieved.
-         - parameter expansion:                An optional array of expansion property names.
-         - parameter dictionaryResult:         The code to be executed after processing the response, containing result
-                                               in dictionary format in case of a success.
-     */
-    static func byId(_ id: String, expansion: [String]?, dictionaryResult: @escaping (Result<[String: Any]>) -> Void)
-
 }
 
 public extension ByIdEndpoint {
     
     static func byId(_ id: String, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
-        byId(id, expansion: expansion, result: result, completionHandler: { response in
-            handleResponse(response, result: result)
-        })
-    }
-    
-    static func byId(_ id: String, expansion: [String]? = nil, dictionaryResult: @escaping (Result<[String: Any]>) -> Void) {
-        byId(id, expansion: expansion, result: dictionaryResult, completionHandler: { response in
-            handleResponse(response, result: dictionaryResult)
-        })
-    }
-    
-    private static func byId<T>(_ id: String, expansion: [String]? = nil, result: @escaping (Result<T>) -> Void, completionHandler: @escaping (DataResponse<Any>) -> Void) {
+        
         requestWithTokenAndPath(result, { token, path in
             let fullPath = pathWithExpansion(path + id, expansion: expansion)
             
             Alamofire.request(fullPath, parameters: nil, encoding: JSONEncoding.default, headers: self.headers(token))
-            .responseJSON(queue: DispatchQueue.global(), completionHandler: completionHandler)
+                .responseJSON(queue: DispatchQueue.global(), completionHandler: { response in
+                    handleResponse(response, result: result)
+                })
         })
     }
 }

--- a/Source/Core/ByKeyEndpoint.swift
+++ b/Source/Core/ByKeyEndpoint.swift
@@ -17,23 +17,43 @@ public protocol ByKeyEndpoint: Endpoint {
 
         - parameter key:                      The key value used retrieve resource.
         - parameter expansion:                An optional array of expansion property names.
-        - parameter result:                   The code to be executed after processing the response.
+        - parameter result:                   The code to be executed after processing the response, providing model
+                                              instance in case of a successful result.
     */
-    static func byKey(_ key: String, expansion: [String]?, result: @escaping (Result<[String: Any]>) -> Void)
+    static func byKey(_ key: String, expansion: [String]?, result: @escaping (Result<ResponseType>) -> Void)
+    
+    /**
+        Retrieves an object by UUID at the endpoint specified with `path` value.
+
+        - parameter key:                      The key value used retrieve resource.
+        - parameter expansion:                An optional array of expansion property names.
+        - parameter dictionaryResult:         The code to be executed after processing the response, containing result
+                                              in dictionary format in case of a success.
+     */
+    static func byKey(_ key: String, expansion: [String]?, dictionaryResult: @escaping (Result<[String: Any]>) -> Void)
 
 }
 
 public extension ByKeyEndpoint {
-
-    static func byKey(_ key: String, expansion: [String]? = nil, result: @escaping (Result<[String: Any]>) -> Void) {
-
+    
+    static func byKey(_ key: String, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
+        byKey(key, expansion: expansion, result: result, completionHandler: { response in
+            handleResponse(response, result: result)
+        })
+    }
+    
+    static func byKey(_ key: String, expansion: [String]? = nil, dictionaryResult: @escaping (Result<[String: Any]>) -> Void) {
+        byKey(key, expansion: expansion, result: dictionaryResult, completionHandler: { response in
+            handleResponse(response, result: dictionaryResult)
+        })
+    }
+    
+    private static func byKey<T>(_ key: String, expansion: [String]? = nil, result: @escaping (Result<T>) -> Void, completionHandler: @escaping (DataResponse<Any>) -> Void) {
         requestWithTokenAndPath(result, { token, path in
             let fullPath = pathWithExpansion("\(path)key=\(key)", expansion: expansion)
-
+            
             Alamofire.request(fullPath, parameters: nil, encoding: JSONEncoding.default, headers: self.headers(token))
-            .responseJSON(queue: DispatchQueue.global(), completionHandler: { response in
-                handleResponse(response, result: result)
-            })
+                .responseJSON(queue: DispatchQueue.global(), completionHandler: completionHandler)
         })
     }
 }

--- a/Source/Core/ByKeyEndpoint.swift
+++ b/Source/Core/ByKeyEndpoint.swift
@@ -21,39 +21,19 @@ public protocol ByKeyEndpoint: Endpoint {
                                               instance in case of a successful result.
     */
     static func byKey(_ key: String, expansion: [String]?, result: @escaping (Result<ResponseType>) -> Void)
-    
-    /**
-        Retrieves an object by UUID at the endpoint specified with `path` value.
-
-        - parameter key:                      The key value used retrieve resource.
-        - parameter expansion:                An optional array of expansion property names.
-        - parameter dictionaryResult:         The code to be executed after processing the response, containing result
-                                              in dictionary format in case of a success.
-     */
-    static func byKey(_ key: String, expansion: [String]?, dictionaryResult: @escaping (Result<[String: Any]>) -> Void)
-
 }
 
 public extension ByKeyEndpoint {
     
     static func byKey(_ key: String, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
-        byKey(key, expansion: expansion, result: result, completionHandler: { response in
-            handleResponse(response, result: result)
-        })
-    }
-    
-    static func byKey(_ key: String, expansion: [String]? = nil, dictionaryResult: @escaping (Result<[String: Any]>) -> Void) {
-        byKey(key, expansion: expansion, result: dictionaryResult, completionHandler: { response in
-            handleResponse(response, result: dictionaryResult)
-        })
-    }
-    
-    private static func byKey<T>(_ key: String, expansion: [String]? = nil, result: @escaping (Result<T>) -> Void, completionHandler: @escaping (DataResponse<Any>) -> Void) {
+        
         requestWithTokenAndPath(result, { token, path in
             let fullPath = pathWithExpansion("\(path)key=\(key)", expansion: expansion)
             
             Alamofire.request(fullPath, parameters: nil, encoding: JSONEncoding.default, headers: self.headers(token))
-                .responseJSON(queue: DispatchQueue.global(), completionHandler: completionHandler)
+                .responseJSON(queue: DispatchQueue.global(), completionHandler: { response in
+                    handleResponse(response, result: result)
+                })
         })
     }
 }

--- a/Source/Core/CreateEndpoint.swift
+++ b/Source/Core/CreateEndpoint.swift
@@ -19,7 +19,8 @@ public protocol CreateEndpoint: Endpoint {
 
         - parameter object:                   Dictionary representation of the draft object to be created.
         - parameter expansion:                An optional array of expansion property names.
-        - parameter result:                   The code to be executed after processing the response.
+     - parameter result:                      The code to be executed after processing the response, providing model
+                                              instance in case of a successful result.
     */
     static func create(_ object: [String: Any], expansion: [String]?, result: @escaping (Result<ResponseType>) -> Void)
     
@@ -28,7 +29,8 @@ public protocol CreateEndpoint: Endpoint {
      
      - parameter object:                   Dictionary representation of the draft object to be created.
      - parameter expansion:                An optional array of expansion property names.
-     - parameter result:                   The code to be executed after processing the response.
+     - parameter dictionaryResult:         The code to be executed after processing the response, containing result
+                                           in dictionary format in case of a success.
      */
     static func create(_ object: [String: Any], expansion: [String]?, dictionaryResult: @escaping (Result<[String: Any]>) -> Void)
 
@@ -53,7 +55,7 @@ public extension CreateEndpoint {
             let fullPath = pathWithExpansion(path, expansion: expansion)
             
             Alamofire.request(fullPath, method: .post, parameters: object, encoding: JSONEncoding.default, headers: self.headers(token))
-                .responseJSON(queue: DispatchQueue.global(), completionHandler: completionHandler)
+            .responseJSON(queue: DispatchQueue.global(), completionHandler: completionHandler)
         })
     }
 }

--- a/Source/Core/CreateEndpoint.swift
+++ b/Source/Core/CreateEndpoint.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Alamofire
+import ObjectMapper
 
 /**
     All endpoints capable of creating new objects should conform to this protocol.
@@ -20,21 +21,39 @@ public protocol CreateEndpoint: Endpoint {
         - parameter expansion:                An optional array of expansion property names.
         - parameter result:                   The code to be executed after processing the response.
     */
-    static func create(_ object: [String: Any], expansion: [String]?, result: @escaping (Result<[String: Any]>) -> Void)
+    static func create(_ object: [String: Any], expansion: [String]?, result: @escaping (Result<ResponseType>) -> Void)
+    
+    /**
+     Creates new object at the endpoint specified with `path` value.
+     
+     - parameter object:                   Dictionary representation of the draft object to be created.
+     - parameter expansion:                An optional array of expansion property names.
+     - parameter result:                   The code to be executed after processing the response.
+     */
+    static func create(_ object: [String: Any], expansion: [String]?, dictionaryResult: @escaping (Result<[String: Any]>) -> Void)
 
 }
 
 public extension CreateEndpoint {
 
-    static func create(_ object: [String: Any], expansion: [String]? = nil, result: @escaping (Result<[String: Any]>) -> Void) {
-
+    static func create(_ object: [String: Any], expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
+        create(object, expansion: expansion, result: result, completionHandler: { response in
+            handleResponse(response, result: result)
+        })
+    }
+    
+    static func create(_ object: [String: Any], expansion: [String]? = nil, dictionaryResult: @escaping (Result<[String: Any]>) -> Void) {
+        create(object, expansion: expansion, result: dictionaryResult, completionHandler: { response in
+            handleResponse(response, result: dictionaryResult)
+        })
+    }
+    
+    private static func create<T>(_ object: [String: Any], expansion: [String]? = nil, result: @escaping (Result<T>) -> Void, completionHandler: @escaping (DataResponse<Any>) -> Void) {
         requestWithTokenAndPath(result, { token, path in
             let fullPath = pathWithExpansion(path, expansion: expansion)
-
+            
             Alamofire.request(fullPath, method: .post, parameters: object, encoding: JSONEncoding.default, headers: self.headers(token))
-            .responseJSON(queue: DispatchQueue.global(), completionHandler: { response in
-                handleResponse(response, result: result)
-            })
+                .responseJSON(queue: DispatchQueue.global(), completionHandler: completionHandler)
         })
     }
 }

--- a/Source/Core/CreateEndpoint.swift
+++ b/Source/Core/CreateEndpoint.swift
@@ -18,43 +18,22 @@ public protocol CreateEndpoint: Endpoint {
 
         - parameter object:                   Dictionary representation of the draft object to be created.
         - parameter expansion:                An optional array of expansion property names.
-     - parameter result:                      The code to be executed after processing the response, providing model
-                                              instance in case of a successful result.
+        - parameter result:                   The code to be executed after processing the response.
     */
     static func create(_ object: [String: Any], expansion: [String]?, result: @escaping (Result<ResponseType>) -> Void)
-    
-    /**
-     Creates new object at the endpoint specified with `path` value.
-     
-     - parameter object:                   Dictionary representation of the draft object to be created.
-     - parameter expansion:                An optional array of expansion property names.
-     - parameter dictionaryResult:         The code to be executed after processing the response, containing result
-                                           in dictionary format in case of a success.
-     */
-    static func create(_ object: [String: Any], expansion: [String]?, dictionaryResult: @escaping (Result<[String: Any]>) -> Void)
-
 }
 
 public extension CreateEndpoint {
 
     static func create(_ object: [String: Any], expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
-        create(object, expansion: expansion, result: result, completionHandler: { response in
-            handleResponse(response, result: result)
-        })
-    }
-    
-    static func create(_ object: [String: Any], expansion: [String]? = nil, dictionaryResult: @escaping (Result<[String: Any]>) -> Void) {
-        create(object, expansion: expansion, result: dictionaryResult, completionHandler: { response in
-            handleResponse(response, result: dictionaryResult)
-        })
-    }
-    
-    private static func create<T>(_ object: [String: Any], expansion: [String]? = nil, result: @escaping (Result<T>) -> Void, completionHandler: @escaping (DataResponse<Any>) -> Void) {
+
         requestWithTokenAndPath(result, { token, path in
             let fullPath = pathWithExpansion(path, expansion: expansion)
-            
+
             Alamofire.request(fullPath, method: .post, parameters: object, encoding: JSONEncoding.default, headers: self.headers(token))
-            .responseJSON(queue: DispatchQueue.global(), completionHandler: completionHandler)
+                    .responseJSON(queue: DispatchQueue.global(), completionHandler: { response in
+                        handleResponse(response, result: result)
+                    })
         })
     }
 }

--- a/Source/Core/CreateEndpoint.swift
+++ b/Source/Core/CreateEndpoint.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 import Alamofire
-import ObjectMapper
 
 /**
     All endpoints capable of creating new objects should conform to this protocol.

--- a/Source/Core/DeleteEndpoint.swift
+++ b/Source/Core/DeleteEndpoint.swift
@@ -22,41 +22,19 @@ public protocol DeleteEndpoint: Endpoint {
                                               instance in case of a successful result.
     */
     static func delete(_ id: String, version: UInt, expansion: [String]?, result: @escaping (Result<ResponseType>) -> Void)
-    
-    /**
-         Deletes an object by UUID at the endpoint specified with `path` value.
-         
-         - parameter id:                       Unique ID of the object to be deleted.
-         - parameter version:                  Version of the object (for optimistic concurrency control).
-         - parameter expansion:                An optional array of expansion property names.
-         - parameter dictionaryResult:         The code to be executed after processing the response, containing result
-                                               in dictionary format in case of a success.
-     */
-    static func delete(_ id: String, version: UInt, expansion: [String]?, dictionaryResult: @escaping (Result<[String: Any]>) -> Void)
-
 }
 
 public extension DeleteEndpoint {
     
     static func delete(_ id: String, version: UInt, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
-        delete(id, version: version, expansion: expansion, result: result, completionHandler: { response in
-            handleResponse(response, result: result)
-        })
-    }
-    
-    static func delete(_ id: String, version: UInt, expansion: [String]? = nil, dictionaryResult: @escaping (Result<[String: Any]>) -> Void) {
-        delete(id, version: version, expansion: expansion, result: dictionaryResult, completionHandler: { response in
-            handleResponse(response, result: dictionaryResult)
-        })
-    }
-    
-    private static func delete<T>(_ id: String, version: UInt, expansion: [String]? = nil, result: @escaping (Result<T>) -> Void, completionHandler: @escaping (DataResponse<Any>) -> Void) {
+        
         requestWithTokenAndPath(result, { token, path in
-            
             let fullPath = pathWithExpansion(path + id, expansion: expansion)
             
             Alamofire.request(fullPath, method: .delete, parameters: ["version": version], encoding: URLEncoding.queryString, headers: self.headers(token))
-            .responseJSON(queue: DispatchQueue.global(), completionHandler: completionHandler)
+                .responseJSON(queue: DispatchQueue.global(), completionHandler: { response in
+                    handleResponse(response, result: result)
+                })
         })
     }
 }

--- a/Source/Core/DeleteEndpoint.swift
+++ b/Source/Core/DeleteEndpoint.swift
@@ -18,23 +18,45 @@ public protocol DeleteEndpoint: Endpoint {
         - parameter id:                       Unique ID of the object to be deleted.
         - parameter version:                  Version of the object (for optimistic concurrency control).
         - parameter expansion:                An optional array of expansion property names.
-        - parameter result:                   The code to be executed after processing the response.
+        - parameter result:                   The code to be executed after processing the response, providing model
+                                              instance in case of a successful result.
     */
-    static func delete(_ id: String, version: UInt, expansion: [String]?, result: @escaping (Result<[String: Any]>) -> Void)
+    static func delete(_ id: String, version: UInt, expansion: [String]?, result: @escaping (Result<ResponseType>) -> Void)
+    
+    /**
+         Deletes an object by UUID at the endpoint specified with `path` value.
+         
+         - parameter id:                       Unique ID of the object to be deleted.
+         - parameter version:                  Version of the object (for optimistic concurrency control).
+         - parameter expansion:                An optional array of expansion property names.
+         - parameter dictionaryResult:         The code to be executed after processing the response, containing result
+                                               in dictionary format in case of a success.
+     */
+    static func delete(_ id: String, version: UInt, expansion: [String]?, dictionaryResult: @escaping (Result<[String: Any]>) -> Void)
 
 }
 
 public extension DeleteEndpoint {
-
-    static func delete(_ id: String, version: UInt, expansion: [String]? = nil, result: @escaping (Result<[String: Any]>) -> Void) {
-
+    
+    static func delete(_ id: String, version: UInt, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
+        delete(id, version: version, expansion: expansion, result: result, completionHandler: { response in
+            handleResponse(response, result: result)
+        })
+    }
+    
+    static func delete(_ id: String, version: UInt, expansion: [String]? = nil, dictionaryResult: @escaping (Result<[String: Any]>) -> Void) {
+        delete(id, version: version, expansion: expansion, result: dictionaryResult, completionHandler: { response in
+            handleResponse(response, result: dictionaryResult)
+        })
+    }
+    
+    private static func delete<T>(_ id: String, version: UInt, expansion: [String]? = nil, result: @escaping (Result<T>) -> Void, completionHandler: @escaping (DataResponse<Any>) -> Void) {
         requestWithTokenAndPath(result, { token, path in
+            
             let fullPath = pathWithExpansion(path + id, expansion: expansion)
-
+            
             Alamofire.request(fullPath, method: .delete, parameters: ["version": version], encoding: URLEncoding.queryString, headers: self.headers(token))
-            .responseJSON(queue: DispatchQueue.global(), completionHandler: { response in
-                handleResponse(response, result: result)
-            })
+            .responseJSON(queue: DispatchQueue.global(), completionHandler: completionHandler)
         })
     }
 }

--- a/Source/Core/Endpoint.swift
+++ b/Source/Core/Endpoint.swift
@@ -82,25 +82,9 @@ public extension Endpoint {
         - parameter result:                   The code to be executed after processing the response, providing response
                                               in dictionary format in case of a successful result.
     */
-    static func handleResponse(_ response: DataResponse<Any>, result: (Result<[String: Any]>) -> Void) {
+    static func handleResponse<T>(_ response: DataResponse<Any>, result: (Result<T>) -> Void) {
         if let responseDict = response.result.value as? [String: Any], let response = response.response, case 200 ... 299 = response.statusCode {
             result(Result.success(responseDict))
-        } else {
-            checkResponseForErrors(response: response, result: result)
-        }
-    }
-
-    /**
-        This method provides default response handling from all endpoints, providing model instance in case of a successful result.
-
-        - parameter token:                    Auth token to be included in the headers.
-        - parameter result:                   The code to be executed after processing the response, providing model
-                                              instance in case of a successful result.
-    */
-    static func handleResponse<T: Mappable>(_ response: DataResponse<Any>, result: (Result<T>) -> Void) {
-        if let json = response.result.value as? [String: Any], let object = Mapper<T>().map(JSON: json), let response = response.response,
-                case 200 ... 299 = response.statusCode {
-            result(Result.success(object))
         } else {
             checkResponseForErrors(response: response, result: result)
         }

--- a/Source/Core/Endpoint.swift
+++ b/Source/Core/Endpoint.swift
@@ -30,6 +30,15 @@ public protocol Endpoint {
 
 }
 
+/**
+    Type used for endpoints which do not have any model specified yet.
+*/
+public struct NoMapping: Mappable {
+    
+    public init?(map: Map) {}
+    mutating public func mapping(map: Map) {}
+}
+
 public extension Endpoint {
 
     /// The full path used to form requests for endpoints.

--- a/Source/Core/Endpoint.swift
+++ b/Source/Core/Endpoint.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Alamofire
+import ObjectMapper
 
 /**
     Base type which all endpoints must conform to.
@@ -22,6 +23,8 @@ import Alamofire
     `static func handleResponse`.
 */
 public protocol Endpoint {
+    
+    associatedtype ResponseType: Mappable
 
     static var path: String { get }
 
@@ -73,24 +76,46 @@ public extension Endpoint {
     }
 
     /**
-        This method provides default response handling from all endpoints.
+        This method provides default response handling from all endpoints, providing successful result in dictionary format.
 
         - parameter token:                    Auth token to be included in the headers.
-        - parameter result:                   The code to be executed after processing the response.
+        - parameter result:                   The code to be executed after processing the response, providing response
+                                              in dictionary format in case of a successful result.
     */
     static func handleResponse(_ response: DataResponse<Any>, result: (Result<[String: Any]>) -> Void) {
-        if let responseDict = response.result.value as? [String: AnyObject], let response = response.response {
-            if case 200 ... 299 = response.statusCode {
-                result(Result.success(responseDict))
+        if let responseDict = response.result.value as? [String: Any], let response = response.response, case 200 ... 299 = response.statusCode {
+            result(Result.success(responseDict))
+        } else {
+            checkResponseForErrors(response: response, result: result)
+        }
+    }
 
-            } else if let errorsResponse = responseDict["errors"] as? [[String: AnyObject]] {
+    /**
+        This method provides default response handling from all endpoints, providing model instance in case of a successful result.
+
+        - parameter token:                    Auth token to be included in the headers.
+        - parameter result:                   The code to be executed after processing the response, providing model
+                                              instance in case of a successful result.
+    */
+    static func handleResponse(_ response: DataResponse<Any>, result: (Result<ResponseType>) -> Void) {
+        if let json = response.result.value as? [String: Any], let object = Mapper<ResponseType>().map(JSON: json), let response = response.response,
+                case 200 ... 299 = response.statusCode {
+            result(Result.success(object))
+        } else {
+            checkResponseForErrors(response: response, result: result)
+        }
+    }
+    
+    static func checkResponseForErrors<T>(response: DataResponse<Any>, result: (Result<T>) -> Void) {
+        if let responseDict = response.result.value as? [String: AnyObject], let response = response.response {
+            if let errorsResponse = responseDict["errors"] as? [[String: AnyObject]] {
                 var errors = [CTError]()
                 errorsResponse.forEach {
                     errors += [CTError(code: $0["code"] as? String ?? "", failureMessage: $0["message"] as? String,
-                               failureDetails: $0["detailedErrorMessage"] as? String, currentVersion: $0["currentVersion"] as? UInt)]
+                                       failureDetails: $0["detailedErrorMessage"] as? String, currentVersion: $0["currentVersion"] as? UInt)]
                 }
                 result(Result.failure(response.statusCode, errors))
-
+                
             } else {
                 result(Result.failure(response.statusCode, [CTError.generalError(reason: CTError.FailureReason(message: responseDict["error"] as? String, details: nil))]))
             }
@@ -105,7 +130,7 @@ public extension Endpoint {
         - parameter result:                   The code to be executed in case an error occurs.
         - parameter requestHandler:           The code to be executed if no error occurs, providing token and path.
     */
-    static func requestWithTokenAndPath(_ result: @escaping (Result<[String: Any]>) -> Void, _ requestHandler: @escaping (String, String) -> Void) {
+    static func requestWithTokenAndPath<T>(_ result: @escaping (Result<T>) -> Void, _ requestHandler: @escaping (String, String) -> Void) {
         guard let config = Config.currentConfig, let path = fullPath, config.validate() else {
             Log.error("Cannot execute command - check if the configuration is valid.")
             result(Result.failure(nil, [CTError.generalError(reason: nil)]))

--- a/Source/Core/Endpoint.swift
+++ b/Source/Core/Endpoint.swift
@@ -97,8 +97,8 @@ public extension Endpoint {
         - parameter result:                   The code to be executed after processing the response, providing model
                                               instance in case of a successful result.
     */
-    static func handleResponse(_ response: DataResponse<Any>, result: (Result<ResponseType>) -> Void) {
-        if let json = response.result.value as? [String: Any], let object = Mapper<ResponseType>().map(JSON: json), let response = response.response,
+    static func handleResponse<T: Mappable>(_ response: DataResponse<Any>, result: (Result<T>) -> Void) {
+        if let json = response.result.value as? [String: Any], let object = Mapper<T>().map(JSON: json), let response = response.response,
                 case 200 ... 299 = response.statusCode {
             result(Result.success(object))
         } else {

--- a/Source/Core/QueryEndpoint.swift
+++ b/Source/Core/QueryEndpoint.swift
@@ -2,8 +2,8 @@
 // Copyright (c) 2016 Commercetools. All rights reserved.
 //
 
-import Foundation
 import Alamofire
+import ObjectMapper
 
 /**
     All endpoints capable of being queried should conform to this protocol.
@@ -20,26 +20,76 @@ public protocol QueryEndpoint: Endpoint {
         - parameter expansion:                An optional array of expansion property names.
         - parameter limit:                    An optional parameter to limit the number of returned results.
         - parameter offset:                   An optional parameter to set the offset of the first returned result.
-        - parameter result:                   The code to be executed after processing the response.
+        - parameter result:                   The code to be executed after processing the response, providing model
+                                              instance in case of a successful result.
     */
     static func query(predicates: [String]?, sort: [String]?, expansion: [String]?,
-                      limit: UInt?, offset: UInt?, result: @escaping (Result<[String: Any]>) -> Void)
+                      limit: UInt?, offset: UInt?, result: @escaping (Result<QueryResponse<ResponseType>>) -> Void)
+    
+    /**
+        Queries for objects at the endpoint specified with `path` value.
+
+        - parameter predicate:                An optional array of predicates used for querying for objects.
+        - parameter sort:                     An optional array of sort options used for sorting the results.
+        - parameter expansion:                An optional array of expansion property names.
+        - parameter limit:                    An optional parameter to limit the number of returned results.
+        - parameter offset:                   An optional parameter to set the offset of the first returned result.
+        - parameter dictionaryResult:         The code to be executed after processing the response, containing result
+                                              in dictionary format in case of a success.
+     */
+    static func query(predicates: [String]?, sort: [String]?, expansion: [String]?,
+                      limit: UInt?, offset: UInt?, dictionaryResult: @escaping (Result<[String: Any]>) -> Void)
 
 }
 
+public class QueryResponse<ResponseType: Mappable>: Mappable {
+    
+    public required init?(map: Map) {}
+    
+    // MARK: - Properties
+    
+    var offset: UInt?
+    var count: UInt?
+    var total: UInt?
+    var results: [ResponseType]?
+    
+    // MARK: - Mappable
+    
+    public func mapping(map: Map) {
+        offset           <- map["offset"]
+        count            <- map["count"]
+        total            <- (map["total"])
+        results          <- (map["results"])
+    }
+}
+
 public extension QueryEndpoint {
-
+    
     static func query(predicates: [String]? = nil, sort: [String]? = nil, expansion: [String]? = nil,
-                      limit: UInt? = nil, offset: UInt? = nil, result: @escaping (Result<[String: Any]>) -> Void) {
-
+                      limit: UInt? = nil, offset: UInt? = nil, result: @escaping (Result<QueryResponse<ResponseType>>) -> Void) {
+        query(predicates: predicates, sort: sort, expansion: expansion, limit: limit, offset: offset,
+              result: result, completionHandler: { response in
+            handleResponse(response, result: result)
+        })
+    }
+    
+    static func query(predicates: [String]? = nil, sort: [String]? = nil, expansion: [String]? = nil,
+                      limit: UInt? = nil, offset: UInt? = nil, dictionaryResult: @escaping (Result<[String: Any]>) -> Void) {
+        query(predicates: predicates, sort: sort, expansion: expansion, limit: limit, offset: offset,
+               result: dictionaryResult, completionHandler: { response in
+            handleResponse(response, result: dictionaryResult)
+        })
+    }
+    
+    private static func query<T>(predicates: [String]? = nil, sort: [String]? = nil, expansion: [String]? = nil,
+                              limit: UInt? = nil, offset: UInt? = nil, result: @escaping (Result<T>) -> Void,
+                              completionHandler: @escaping (DataResponse<Any>) -> Void) {
         requestWithTokenAndPath(result, { token, path in
             let fullPath = pathWithExpansion(path, expansion: expansion)
             let parameters = queryParameters(predicates: predicates, sort: sort, limit: limit, offset: offset)
-
+            
             Alamofire.request(fullPath, parameters: parameters, encoding: URLEncoding.queryString, headers: self.headers(token))
-            .responseJSON(queue: DispatchQueue.global(), completionHandler: { response in
-                handleResponse(response, result: result)
-            })
+            .responseJSON(queue: DispatchQueue.global(), completionHandler: completionHandler)
         })
     }
 

--- a/Source/Core/QueryEndpoint.swift
+++ b/Source/Core/QueryEndpoint.swift
@@ -25,20 +25,6 @@ public protocol QueryEndpoint: Endpoint {
     */
     static func query(predicates: [String]?, sort: [String]?, expansion: [String]?,
                       limit: UInt?, offset: UInt?, result: @escaping (Result<QueryResponse<ResponseType>>) -> Void)
-    
-    /**
-        Queries for objects at the endpoint specified with `path` value.
-
-        - parameter predicate:                An optional array of predicates used for querying for objects.
-        - parameter sort:                     An optional array of sort options used for sorting the results.
-        - parameter expansion:                An optional array of expansion property names.
-        - parameter limit:                    An optional parameter to limit the number of returned results.
-        - parameter offset:                   An optional parameter to set the offset of the first returned result.
-        - parameter dictionaryResult:         The code to be executed after processing the response, containing result
-                                              in dictionary format in case of a success.
-     */
-    static func query(predicates: [String]?, sort: [String]?, expansion: [String]?,
-                      limit: UInt?, offset: UInt?, dictionaryResult: @escaping (Result<[String: Any]>) -> Void)
 
 }
 
@@ -67,29 +53,15 @@ public extension QueryEndpoint {
     
     static func query(predicates: [String]? = nil, sort: [String]? = nil, expansion: [String]? = nil,
                       limit: UInt? = nil, offset: UInt? = nil, result: @escaping (Result<QueryResponse<ResponseType>>) -> Void) {
-        query(predicates: predicates, sort: sort, expansion: expansion, limit: limit, offset: offset,
-              result: result, completionHandler: { response in
-            handleResponse(response, result: result)
-        })
-    }
-    
-    static func query(predicates: [String]? = nil, sort: [String]? = nil, expansion: [String]? = nil,
-                      limit: UInt? = nil, offset: UInt? = nil, dictionaryResult: @escaping (Result<[String: Any]>) -> Void) {
-        query(predicates: predicates, sort: sort, expansion: expansion, limit: limit, offset: offset,
-               result: dictionaryResult, completionHandler: { response in
-            handleResponse(response, result: dictionaryResult)
-        })
-    }
-    
-    private static func query<T>(predicates: [String]? = nil, sort: [String]? = nil, expansion: [String]? = nil,
-                              limit: UInt? = nil, offset: UInt? = nil, result: @escaping (Result<T>) -> Void,
-                              completionHandler: @escaping (DataResponse<Any>) -> Void) {
+        
         requestWithTokenAndPath(result, { token, path in
             let fullPath = pathWithExpansion(path, expansion: expansion)
             let parameters = queryParameters(predicates: predicates, sort: sort, limit: limit, offset: offset)
             
             Alamofire.request(fullPath, parameters: parameters, encoding: URLEncoding.queryString, headers: self.headers(token))
-            .responseJSON(queue: DispatchQueue.global(), completionHandler: completionHandler)
+                .responseJSON(queue: DispatchQueue.global(), completionHandler: { response in
+                    handleResponse(response, result: result)
+                })
         })
     }
 

--- a/Source/Core/UpdateByKeyEndpoint.swift
+++ b/Source/Core/UpdateByKeyEndpoint.swift
@@ -19,23 +19,46 @@ public protocol UpdateByKeyEndpoint: Endpoint {
         - parameter version:                  Version of the object (for optimistic concurrency control).
         - parameter actions:                  An array of actions to be executed, in dictionary representation.
         - parameter expansion:                An optional array of expansion property names.
-        - parameter result:                   The code to be executed after processing the response.
+        - parameter result:                   The code to be executed after processing the response, providing model
+                                              instance in case of a successful result.
     */
-    static func updateByKey(_ key: String, version: UInt, actions: [[String: Any]], expansion: [String]?, result: @escaping (Result<[String: Any]>) -> Void)
+    static func updateByKey(_ key: String, version: UInt, actions: [[String: Any]], expansion: [String]?, result: @escaping (Result<ResponseType>) -> Void)
+    
+    /**
+        Updates an object by UUID at the endpoint specified with `path` value.
+
+        - parameter key:                      The key value used to reference resource to be updated.
+        - parameter version:                  Version of the object (for optimistic concurrency control).
+        - parameter actions:                  An array of actions to be executed, in dictionary representation.
+        - parameter expansion:                An optional array of expansion property names.
+        - parameter dictionaryResult:         The code to be executed after processing the response, containing result
+                                              in dictionary format in case of a success.
+     */
+    static func updateByKey(_ key: String, version: UInt, actions: [[String: Any]], expansion: [String]?, dictionaryResult: @escaping (Result<[String: Any]>) -> Void)
 
 }
 
 public extension UpdateByKeyEndpoint {
-
-    static func updateByKey(_ key: String, version: UInt, actions: [[String: Any]], expansion: [String]? = nil, result: @escaping (Result<[String: Any]>) -> Void) {
-
+    
+    static func updateByKey(_ key: String, version: UInt, actions: [[String: Any]], expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
+        updateByKey(key, version: version, actions: actions, expansion: expansion, result: result, completionHandler: { response in
+            handleResponse(response, result: result)
+        })
+    }
+    
+    static func updateByKey(_ key: String, version: UInt, actions: [[String: Any]], expansion: [String]? = nil, dictionaryResult: @escaping (Result<[String: Any]>) -> Void) {
+        updateByKey(key, version: version, actions: actions, expansion: expansion, result: dictionaryResult, completionHandler: { response in
+            handleResponse(response, result: dictionaryResult)
+        })
+    }
+    
+    private static func updateByKey<T>(_ key: String, version: UInt, actions: [[String: Any]], expansion: [String]? = nil, result: @escaping (Result<T>) -> Void,
+                               completionHandler: @escaping (DataResponse<Any>) -> Void) {
         requestWithTokenAndPath(result, { token, path in
             let fullPath = pathWithExpansion("\(path)key=\(key)", expansion: expansion)
-
+            
             Alamofire.request(fullPath, method: .post, parameters: ["version": version, "actions": actions], encoding: JSONEncoding.default, headers: self.headers(token))
-            .responseJSON(queue: DispatchQueue.global(), completionHandler: { response in
-                handleResponse(response, result: result)
-            })
+            .responseJSON(queue: DispatchQueue.global(), completionHandler: completionHandler)
         })
     }
 }

--- a/Source/Core/UpdateByKeyEndpoint.swift
+++ b/Source/Core/UpdateByKeyEndpoint.swift
@@ -23,42 +23,19 @@ public protocol UpdateByKeyEndpoint: Endpoint {
                                               instance in case of a successful result.
     */
     static func updateByKey(_ key: String, version: UInt, actions: [[String: Any]], expansion: [String]?, result: @escaping (Result<ResponseType>) -> Void)
-    
-    /**
-        Updates an object by UUID at the endpoint specified with `path` value.
-
-        - parameter key:                      The key value used to reference resource to be updated.
-        - parameter version:                  Version of the object (for optimistic concurrency control).
-        - parameter actions:                  An array of actions to be executed, in dictionary representation.
-        - parameter expansion:                An optional array of expansion property names.
-        - parameter dictionaryResult:         The code to be executed after processing the response, containing result
-                                              in dictionary format in case of a success.
-     */
-    static func updateByKey(_ key: String, version: UInt, actions: [[String: Any]], expansion: [String]?, dictionaryResult: @escaping (Result<[String: Any]>) -> Void)
-
 }
 
 public extension UpdateByKeyEndpoint {
     
     static func updateByKey(_ key: String, version: UInt, actions: [[String: Any]], expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
-        updateByKey(key, version: version, actions: actions, expansion: expansion, result: result, completionHandler: { response in
-            handleResponse(response, result: result)
-        })
-    }
-    
-    static func updateByKey(_ key: String, version: UInt, actions: [[String: Any]], expansion: [String]? = nil, dictionaryResult: @escaping (Result<[String: Any]>) -> Void) {
-        updateByKey(key, version: version, actions: actions, expansion: expansion, result: dictionaryResult, completionHandler: { response in
-            handleResponse(response, result: dictionaryResult)
-        })
-    }
-    
-    private static func updateByKey<T>(_ key: String, version: UInt, actions: [[String: Any]], expansion: [String]? = nil, result: @escaping (Result<T>) -> Void,
-                               completionHandler: @escaping (DataResponse<Any>) -> Void) {
+        
         requestWithTokenAndPath(result, { token, path in
             let fullPath = pathWithExpansion("\(path)key=\(key)", expansion: expansion)
             
             Alamofire.request(fullPath, method: .post, parameters: ["version": version, "actions": actions], encoding: JSONEncoding.default, headers: self.headers(token))
-            .responseJSON(queue: DispatchQueue.global(), completionHandler: completionHandler)
+                .responseJSON(queue: DispatchQueue.global(), completionHandler: { response in
+                    handleResponse(response, result: result)
+                })
         })
     }
 }

--- a/Source/Core/UpdateEndpoint.swift
+++ b/Source/Core/UpdateEndpoint.swift
@@ -23,42 +23,19 @@ public protocol UpdateEndpoint: Endpoint {
                                               instance in case of a successful result.
     */
     static func update(_ id: String, version: UInt, actions: [[String: Any]], expansion: [String]?, result: @escaping (Result<ResponseType>) -> Void)
-    
-    /**
-        Updates an object by UUID at the endpoint specified with `path` value.
-
-        - parameter id:                       Unique ID of the object to be deleted.
-        - parameter version:                  Version of the object (for optimistic concurrency control).
-        - parameter actions:                  An array of actions to be executed, in dictionary representation.
-        - parameter expansion:                An optional array of expansion property names.
-        - parameter dictionaryResult:         The code to be executed after processing the response, containing result
-                                              in dictionary format in case of a success.
-     */
-    static func update(_ id: String, version: UInt, actions: [[String: Any]], expansion: [String]?, dictionaryResult: @escaping (Result<[String: Any]>) -> Void)
-
 }
 
 public extension UpdateEndpoint {
     
     static func update(_ id: String, version: UInt, actions: [[String: Any]], expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
-        update(id, version: version, actions: actions, expansion: expansion, result: result, completionHandler: { response in
-            handleResponse(response, result: result)
-        })
-    }
-    
-    static func update(_ id: String, version: UInt, actions: [[String: Any]], expansion: [String]? = nil, dictionaryResult: @escaping (Result<[String: Any]>) -> Void) {
-        update(id, version: version, actions: actions, expansion: expansion, result: dictionaryResult, completionHandler: { response in
-            handleResponse(response, result: dictionaryResult)
-        })
-    }
-    
-    private static func update<T>(_ id: String, version: UInt, actions: [[String: Any]], expansion: [String]? = nil, result: @escaping (Result<T>) -> Void,
-                               completionHandler: @escaping (DataResponse<Any>) -> Void) {
+        
         requestWithTokenAndPath(result, { token, path in
             let fullPath = pathWithExpansion(path + id, expansion: expansion)
             
             Alamofire.request(fullPath, method: .post, parameters: ["version": version, "actions": actions], encoding: JSONEncoding.default, headers: self.headers(token))
-            .responseJSON(queue: DispatchQueue.global(), completionHandler: completionHandler)
+                .responseJSON(queue: DispatchQueue.global(), completionHandler: { response in
+                    handleResponse(response, result: result)
+                })
         })
     }
 }

--- a/Source/Core/UpdateEndpoint.swift
+++ b/Source/Core/UpdateEndpoint.swift
@@ -19,23 +19,46 @@ public protocol UpdateEndpoint: Endpoint {
         - parameter version:                  Version of the object (for optimistic concurrency control).
         - parameter actions:                  An array of actions to be executed, in dictionary representation.
         - parameter expansion:                An optional array of expansion property names.
-        - parameter result:                   The code to be executed after processing the response.
+        - parameter result:                   The code to be executed after processing the response, providing model
+                                              instance in case of a successful result.
     */
-    static func update(_ id: String, version: UInt, actions: [[String: Any]], expansion: [String]?, result: @escaping (Result<[String: Any]>) -> Void)
+    static func update(_ id: String, version: UInt, actions: [[String: Any]], expansion: [String]?, result: @escaping (Result<ResponseType>) -> Void)
+    
+    /**
+        Updates an object by UUID at the endpoint specified with `path` value.
+
+        - parameter id:                       Unique ID of the object to be deleted.
+        - parameter version:                  Version of the object (for optimistic concurrency control).
+        - parameter actions:                  An array of actions to be executed, in dictionary representation.
+        - parameter expansion:                An optional array of expansion property names.
+        - parameter dictionaryResult:         The code to be executed after processing the response, containing result
+                                              in dictionary format in case of a success.
+     */
+    static func update(_ id: String, version: UInt, actions: [[String: Any]], expansion: [String]?, dictionaryResult: @escaping (Result<[String: Any]>) -> Void)
 
 }
 
 public extension UpdateEndpoint {
-
-    static func update(_ id: String, version: UInt, actions: [[String: Any]], expansion: [String]? = nil, result: @escaping (Result<[String: Any]>) -> Void) {
-
+    
+    static func update(_ id: String, version: UInt, actions: [[String: Any]], expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
+        update(id, version: version, actions: actions, expansion: expansion, result: result, completionHandler: { response in
+            handleResponse(response, result: result)
+        })
+    }
+    
+    static func update(_ id: String, version: UInt, actions: [[String: Any]], expansion: [String]? = nil, dictionaryResult: @escaping (Result<[String: Any]>) -> Void) {
+        update(id, version: version, actions: actions, expansion: expansion, result: dictionaryResult, completionHandler: { response in
+            handleResponse(response, result: dictionaryResult)
+        })
+    }
+    
+    private static func update<T>(_ id: String, version: UInt, actions: [[String: Any]], expansion: [String]? = nil, result: @escaping (Result<T>) -> Void,
+                               completionHandler: @escaping (DataResponse<Any>) -> Void) {
         requestWithTokenAndPath(result, { token, path in
             let fullPath = pathWithExpansion(path + id, expansion: expansion)
-
+            
             Alamofire.request(fullPath, method: .post, parameters: ["version": version, "actions": actions], encoding: JSONEncoding.default, headers: self.headers(token))
-            .responseJSON(queue: DispatchQueue.global(), completionHandler: { response in
-                handleResponse(response, result: result)
-            })
+            .responseJSON(queue: DispatchQueue.global(), completionHandler: completionHandler)
         })
     }
 }

--- a/Source/Endpoints/ActiveCart.swift
+++ b/Source/Endpoints/ActiveCart.swift
@@ -15,38 +15,20 @@ class ActiveCart: Endpoint {
     static let path = "me/active-cart"
 
     /**
-        Retrieves the cart with state Active which has the most recent lastModifiedAt.
-
-        - parameter expansion:                An optional array of expansion property names.
-        - parameter result:                   The code to be executed after processing the response, providing model
-                                              instance in case of a successful result.
-    */
+     Retrieves the cart with state Active which has the most recent lastModifiedAt.
+     
+     - parameter expansion:                An optional array of expansion property names.
+     - parameter result:                   The code to be executed after processing the response.
+     */
     static func get(expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
-        get(expansion: expansion, result: result, completionHandler: { response in
-            handleResponse(response, result: result)
-        })
-    }
-
-    /**
-        Retrieves the cart with state Active which has the most recent lastModifiedAt.
-
-        - parameter expansion:                An optional array of expansion property names.
-        - parameter dictionaryResult:         The code to be executed after processing the response, containing result
-                                              in dictionary format in case of a success.
-    */
-    static func get(expansion: [String]? = nil, dictionaryResult: @escaping (Result<[String: Any]>) -> Void) {
-        get(expansion: expansion, result: dictionaryResult, completionHandler: { response in
-            handleResponse(response, result: dictionaryResult)
-        })
-    }
-
-    private static func get<T>(expansion: [String]? = nil, result: @escaping (Result<T>) -> Void, completionHandler: @escaping (DataResponse<Any>) -> Void) {
+        
         requestWithTokenAndPath(result, { token, path in
             let fullPath = pathWithExpansion(path, expansion: expansion)
-
+            
             Alamofire.request(fullPath, parameters: nil, encoding: JSONEncoding.default, headers: self.headers(token))
-            .responseJSON(queue: DispatchQueue.global(), completionHandler: completionHandler)
+                .responseJSON(queue: DispatchQueue.global(), completionHandler: { response in
+                    handleResponse(response, result: result)
+                })
         })
     }
-
 }

--- a/Source/Endpoints/ActiveCart.swift
+++ b/Source/Endpoints/ActiveCart.swift
@@ -2,13 +2,15 @@
 // Copyright (c) 2016 Commercetools. All rights reserved.
 //
 
-import Foundation
 import Alamofire
+import ObjectMapper
 
 /**
     Provides access to active cart endpoint.
 */
 class ActiveCart: Endpoint {
+    
+    public typealias ResponseType = Cart
 
     static let path = "me/active-cart"
 
@@ -18,7 +20,7 @@ class ActiveCart: Endpoint {
         - parameter expansion:                An optional array of expansion property names.
         - parameter result:                   The code to be executed after processing the response.
     */
-    static func get(_ expansion: [String]? = nil, result: @escaping (Result<[String: Any]>) -> Void) {
+    static func get(_ expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
 
         requestWithTokenAndPath(result, { token, path in
             let fullPath = pathWithExpansion(path, expansion: expansion)

--- a/Source/Endpoints/ActiveCart.swift
+++ b/Source/Endpoints/ActiveCart.swift
@@ -18,17 +18,34 @@ class ActiveCart: Endpoint {
         Retrieves the cart with state Active which has the most recent lastModifiedAt.
 
         - parameter expansion:                An optional array of expansion property names.
-        - parameter result:                   The code to be executed after processing the response.
+        - parameter result:                   The code to be executed after processing the response, providing model
+                                              instance in case of a successful result.
     */
-    static func get(_ expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
+    static func get(expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
+        get(expansion: expansion, result: result, completionHandler: { response in
+            handleResponse(response, result: result)
+        })
+    }
 
+    /**
+        Retrieves the cart with state Active which has the most recent lastModifiedAt.
+
+        - parameter expansion:                An optional array of expansion property names.
+        - parameter dictionaryResult:         The code to be executed after processing the response, containing result
+                                              in dictionary format in case of a success.
+    */
+    static func get(expansion: [String]? = nil, dictionaryResult: @escaping (Result<[String: Any]>) -> Void) {
+        get(expansion: expansion, result: dictionaryResult, completionHandler: { response in
+            handleResponse(response, result: dictionaryResult)
+        })
+    }
+
+    private static func get<T>(expansion: [String]? = nil, result: @escaping (Result<T>) -> Void, completionHandler: @escaping (DataResponse<Any>) -> Void) {
         requestWithTokenAndPath(result, { token, path in
             let fullPath = pathWithExpansion(path, expansion: expansion)
 
             Alamofire.request(fullPath, parameters: nil, encoding: JSONEncoding.default, headers: self.headers(token))
-            .responseJSON(queue: DispatchQueue.global(), completionHandler: { response in
-                handleResponse(response, result: result)
-            })
+            .responseJSON(queue: DispatchQueue.global(), completionHandler: completionHandler)
         })
     }
 

--- a/Source/Endpoints/Cart.swift
+++ b/Source/Endpoints/Cart.swift
@@ -18,17 +18,6 @@ open class Cart: QueryEndpoint, ByIdEndpoint, CreateEndpoint, UpdateEndpoint, De
      Retrieves the cart with state Active which has the most recent lastModifiedAt.
      
          - parameter expansion:                An optional array of expansion property names.
-         - parameter dictionaryResult:         The code to be executed after processing the response, containing result
-                                               in dictionary format in case of a success.
-     */
-    open static func active(expansion: [String]? = nil, dictionaryResult: @escaping (Result<[String: Any]>) -> Void) {
-        return ActiveCart.get(expansion: expansion, dictionaryResult: dictionaryResult)
-    }
-
-    /**
-     Retrieves the cart with state Active which has the most recent lastModifiedAt.
-     
-         - parameter expansion:                An optional array of expansion property names.
          - parameter result:                   The code to be executed after processing the response, providing model
                                                instance in case of a successful result.
      */

--- a/Source/Endpoints/Cart.swift
+++ b/Source/Endpoints/Cart.swift
@@ -16,13 +16,25 @@ open class Cart: QueryEndpoint, ByIdEndpoint, CreateEndpoint, UpdateEndpoint, De
     open static let path = "me/carts"
 
     /**
-        Retrieves the cart with state Active which has the most recent lastModifiedAt.
+     Retrieves the cart with state Active which has the most recent lastModifiedAt.
+     
+         - parameter expansion:                An optional array of expansion property names.
+         - parameter dictionaryResult:         The code to be executed after processing the response, containing result
+                                               in dictionary format in case of a success.
+     */
+    open static func active(expansion: [String]? = nil, dictionaryResult: @escaping (Result<[String: Any]>) -> Void) {
+        return ActiveCart.get(expansion: expansion, dictionaryResult: dictionaryResult)
+    }
 
-        - parameter expansion:                An optional array of expansion property names.
-        - parameter result:                   The code to be executed after processing the response.
-    */
-    open static func active(_ expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
-        return ActiveCart.get(expansion, result: result)
+    /**
+     Retrieves the cart with state Active which has the most recent lastModifiedAt.
+     
+         - parameter expansion:                An optional array of expansion property names.
+         - parameter result:                   The code to be executed after processing the response, providing model
+                                               instance in case of a successful result.
+     */
+    open static func active(expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
+        return ActiveCart.get(expansion: expansion, result: result)
     }
     
     // MARK: - Properties

--- a/Source/Endpoints/Cart.swift
+++ b/Source/Endpoints/Cart.swift
@@ -43,6 +43,8 @@ open class Cart: QueryEndpoint, ByIdEndpoint, CreateEndpoint, UpdateEndpoint, De
     var version: UInt?
     var createdAt: Date?
     var lastModifiedAt: Date?
+    var customerId: String?
+    
     var lineItems: [LineItem]?
     var totalPrice: Money?
     var taxedPrice: TaxedPrice?

--- a/Source/Endpoints/Cart.swift
+++ b/Source/Endpoints/Cart.swift
@@ -4,11 +4,14 @@
 
 import Foundation
 import Alamofire
+import ObjectMapper
 
 /**
     Provides complete set of interactions for querying, retrieving, creating and updating shopping cart.
 */
-open class Cart: QueryEndpoint, ByIdEndpoint, CreateEndpoint, UpdateEndpoint, DeleteEndpoint {
+open class Cart: QueryEndpoint, ByIdEndpoint, CreateEndpoint, UpdateEndpoint, DeleteEndpoint, Mappable {
+    
+    public typealias ResponseType = Cart
 
     open static let path = "me/carts"
 
@@ -18,8 +21,34 @@ open class Cart: QueryEndpoint, ByIdEndpoint, CreateEndpoint, UpdateEndpoint, De
         - parameter expansion:                An optional array of expansion property names.
         - parameter result:                   The code to be executed after processing the response.
     */
-    open static func active(_ expansion: [String]? = nil, result: @escaping (Result<[String: Any]>) -> Void) {
+    open static func active(_ expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
         return ActiveCart.get(expansion, result: result)
+    }
+    
+    // MARK: - Properties
+    
+    var id: String?
+    var version: UInt?
+    var createdAt: Date?
+    var lastModifiedAt: Date?
+    var lineItems: [LineItem]?
+    var totalPrice: Money?
+    var taxedPrice: TaxedPrice?
+    var country: String?
+    
+    public required init?(map: Map) {}
+    
+    // MARK: - Mappable
+    
+    public func mapping(map: Map) {
+        id               <- map["id"]
+        version          <- map["version"]
+        createdAt        <- (map["createdAt"], ISO8601DateTransform())
+        lastModifiedAt   <- (map["lastModifiedAt"], ISO8601DateTransform())
+        lineItems        <- map["lineItems"]
+        totalPrice       <- map["totalPrice"]
+        taxedPrice       <- map["taxedPrice"]
+        country          <- map["country"]
     }
 
 }

--- a/Source/Endpoints/Cart.swift
+++ b/Source/Endpoints/Cart.swift
@@ -2,7 +2,6 @@
 // Copyright (c) 2016 Commercetools. All rights reserved.
 //
 
-import Foundation
 import Alamofire
 import ObjectMapper
 
@@ -44,11 +43,24 @@ open class Cart: QueryEndpoint, ByIdEndpoint, CreateEndpoint, UpdateEndpoint, De
     var createdAt: Date?
     var lastModifiedAt: Date?
     var customerId: String?
-    
+    var customerEmail: String?
+    var anonymousId: String?
     var lineItems: [LineItem]?
+    var customLineItems: [CustomLineItem]?
     var totalPrice: Money?
     var taxedPrice: TaxedPrice?
+    var cartState: CartState?
+    var shippingAddress: Address?
+    var billingAddress: Address?
+    var inventoryMode: InventoryMode?
+    var taxMode: TaxMode?
+    var customerGroup: Reference<CustomerGroup>?
     var country: String?
+    var shippingInfo: ShippingInfo?
+    var discountCodes: [DiscountCodeInfo]?
+    var custom: [String: Any]?
+    var paymentInfo: PaymentInfo?
+    var locale: String?
     
     public required init?(map: Map) {}
     
@@ -59,10 +71,24 @@ open class Cart: QueryEndpoint, ByIdEndpoint, CreateEndpoint, UpdateEndpoint, De
         version          <- map["version"]
         createdAt        <- (map["createdAt"], ISO8601DateTransform())
         lastModifiedAt   <- (map["lastModifiedAt"], ISO8601DateTransform())
+        customerId       <- map["customerId"]
+        customerEmail    <- map["customerEmail"]
+        anonymousId      <- map["anonymousId"]
         lineItems        <- map["lineItems"]
+        customLineItems  <- map["customLineItems"]
         totalPrice       <- map["totalPrice"]
         taxedPrice       <- map["taxedPrice"]
+        cartState        <- map["cartState"]
+        shippingAddress  <- map["shippingAddress"]
+        billingAddress   <- map["billingAddress"]
+        inventoryMode    <- map["inventoryMode"]
+        taxMode          <- map["taxMode"]
+        customerGroup    <- map["customerGroup"]
         country          <- map["country"]
+        shippingInfo     <- map["shippingInfo"]
+        custom           <- map["custom"]
+        paymentInfo      <- map["paymentInfo"]
+        locale           <- map["locale"]
     }
 
 }

--- a/Source/Endpoints/Category.swift
+++ b/Source/Endpoints/Category.swift
@@ -2,13 +2,23 @@
 // Copyright (c) 2016 Commercetools. All rights reserved.
 //
 
-import Foundation
+import ObjectMapper
 
 /**
     Provides set of interactions for querying and retrieving by UUID for categories.
 */
-open class Category: ByIdEndpoint, QueryEndpoint {
+open class Category: ByIdEndpoint, QueryEndpoint, Mappable {
+    
+    public typealias ResponseType = Category
 
     open static let path = "categories"
+    
+    // MARK: - Properties
+    
+    public required init?(map: Map) {}
+    
+    // MARK: - Mappable
+    
+    public func mapping(map: Map) {}
 
 }

--- a/Source/Endpoints/Category.swift
+++ b/Source/Endpoints/Category.swift
@@ -7,18 +7,9 @@ import ObjectMapper
 /**
     Provides set of interactions for querying and retrieving by UUID for categories.
 */
-open class Category: ByIdEndpoint, QueryEndpoint, Mappable {
+open class Category: ByIdEndpoint, QueryEndpoint {
     
-    public typealias ResponseType = Category
+    public typealias ResponseType = NoMapping
 
     open static let path = "categories"
-    
-    // MARK: - Properties
-    
-    public required init?(map: Map) {}
-    
-    // MARK: - Mappable
-    
-    public func mapping(map: Map) {}
-
 }

--- a/Source/Endpoints/Customer.swift
+++ b/Source/Endpoints/Customer.swift
@@ -2,14 +2,16 @@
 // Copyright (c) 2016 Commercetools. All rights reserved.
 //
 
-import Foundation
 import Alamofire
+import ObjectMapper
 
 /**
     Provides complete set of interactions for retrieving current customer profile, signing up,
     updating and profile deletion.
 */
-open class Customer: Endpoint {
+open class Customer: Endpoint, Mappable {
+    
+    public typealias ResponseType = Customer
 
     // MARK: - Properties
 
@@ -112,7 +114,13 @@ open class Customer: Endpoint {
 
         customerProfileAction(method: .post, basePath: "email/confirm", parameters: ["tokenValue": token],
                               encoding: JSONEncoding.default, result: result)
-    }
+    }        
+    
+    public required init?(map: Map) {}
+    
+    // MARK: - Mappable
+    
+    public func mapping(map: Map) {}
 
     // MARK: - Helpers
 

--- a/Source/Endpoints/Customer.swift
+++ b/Source/Endpoints/Customer.swift
@@ -16,11 +16,11 @@ open class Customer: Endpoint, Mappable {
     // MARK: - Properties
 
     open static let path = "me"
-    
+
     public required init?(map: Map) {}
-    
+
     // MARK: - Mappable
-    
+
     public func mapping(map: Map) {}
 
     // MARK: - Customer endpoint functionality

--- a/Source/Endpoints/Customer.swift
+++ b/Source/Endpoints/Customer.swift
@@ -30,7 +30,7 @@ open class Customer: Endpoint, Mappable {
 
         - parameter result:                   The code to be executed after processing the response.
     */
-    open static func profile(_ result: @escaping (Result<[String: Any]>) -> Void) {
+    open static func profile(_ result: @escaping (Result<ResponseType>) -> Void) {
         customerProfileAction(method: .get, result: result)
     }
 
@@ -40,7 +40,7 @@ open class Customer: Endpoint, Mappable {
         - parameter profile:                  Dictionary representation of the draft customer profile to be created.
         - parameter result:                   The code to be executed after processing the response.
     */
-    open static func signup(_ profile: [String: Any], result: @escaping (Result<[String: Any]>) -> Void) {
+    open static func signup(_ profile: [String: Any], result: @escaping (Result<ResponseType>) -> Void) {
         customerProfileAction(method: .post, basePath: "signup", parameters: profile, encoding: JSONEncoding.default, result: result)
     }
 
@@ -51,7 +51,7 @@ open class Customer: Endpoint, Mappable {
         - parameter actions:                  An array of actions to be executed, in dictionary representation.
         - parameter result:                   The code to be executed after processing the response.
     */
-    open static func update(version: UInt, actions: [[String: Any]], result: @escaping (Result<[String: Any]>) -> Void) {
+    open static func update(version: UInt, actions: [[String: Any]], result: @escaping (Result<ResponseType>) -> Void) {
         customerProfileAction(method: .post, parameters: ["version": version, "actions": actions], encoding: JSONEncoding.default, result: result)
     }
 
@@ -61,7 +61,7 @@ open class Customer: Endpoint, Mappable {
         - parameter version:                  Customer profile version (for optimistic concurrency control).
         - parameter result:                   The code to be executed after processing the response.
     */
-    open static func delete(version: UInt, result: @escaping (Result<[String: Any]>) -> Void) {
+    open static func delete(version: UInt, result: @escaping (Result<ResponseType>) -> Void) {
         customerProfileAction(method: .delete, parameters: ["version": version], result: result)
     }
 
@@ -76,12 +76,12 @@ open class Customer: Endpoint, Mappable {
         - parameter result:                   The code to be executed after processing the response.
     */
     open static func changePassword(currentPassword: String, newPassword: String, version: UInt,
-                               result: @escaping (Result<[String: Any]>) -> Void) {
+                               result: @escaping (Result<ResponseType>) -> Void) {
 
         customerProfileAction(method: .post, basePath: "password", parameters: ["currentPassword": currentPassword,
                               "newPassword": newPassword, "version": version], encoding: JSONEncoding.default, result: { changePasswordResult in
 
-            if let response = changePasswordResult.response, let email = response["email"] as? String, changePasswordResult.isSuccess {
+            if let response = changePasswordResult.json, let email = response["email"] as? String, changePasswordResult.isSuccess {
                 AuthManager.sharedInstance.loginUser(email, password: newPassword, completionHandler: { error in
                     if let error = error as? CTError {
                         Log.error("Could not login automatically after password change "
@@ -102,7 +102,7 @@ open class Customer: Endpoint, Mappable {
         - parameter newPassword:              The new password.
         - parameter result:                   The code to be executed after processing the response.
     */
-    open static func resetPassword(token: String, newPassword: String, result: @escaping (Result<[String: Any]>) -> Void) {
+    open static func resetPassword(token: String, newPassword: String, result: @escaping (Result<ResponseType>) -> Void) {
 
         customerProfileAction(method: .post, basePath: "password/reset", parameters: ["tokenValue": token,
                               "newPassword": newPassword], encoding: JSONEncoding.default, result: result)
@@ -116,7 +116,7 @@ open class Customer: Endpoint, Mappable {
                                               Usually parsed from the account activation URL.
         - parameter result:                   The code to be executed after processing the response.
     */
-    open static func verifyEmail(token: String, result: @escaping (Result<[String: Any]>) -> Void) {
+    open static func verifyEmail(token: String, result: @escaping (Result<ResponseType>) -> Void) {
 
         customerProfileAction(method: .post, basePath: "email/confirm", parameters: ["tokenValue": token],
                               encoding: JSONEncoding.default, result: result)
@@ -126,7 +126,7 @@ open class Customer: Endpoint, Mappable {
 
     private static func customerProfileAction(method: HTTPMethod, basePath: String? = nil,
                                               parameters: [String: Any]? = nil, encoding: ParameterEncoding = URLEncoding.default,
-                                              result: @escaping (Result<[String: Any]>) -> Void) {
+                                              result: @escaping (Result<ResponseType>) -> Void) {
 
         requestWithTokenAndPath(result, { token, path in
             Alamofire.request(path + (basePath ?? ""), method: method, parameters: parameters, encoding: encoding, headers: self.headers(token))

--- a/Source/Endpoints/Customer.swift
+++ b/Source/Endpoints/Customer.swift
@@ -16,6 +16,12 @@ open class Customer: Endpoint, Mappable {
     // MARK: - Properties
 
     open static let path = "me"
+    
+    public required init?(map: Map) {}
+    
+    // MARK: - Mappable
+    
+    public func mapping(map: Map) {}
 
     // MARK: - Customer endpoint functionality
 
@@ -114,14 +120,8 @@ open class Customer: Endpoint, Mappable {
 
         customerProfileAction(method: .post, basePath: "email/confirm", parameters: ["tokenValue": token],
                               encoding: JSONEncoding.default, result: result)
-    }        
+    }
     
-    public required init?(map: Map) {}
-    
-    // MARK: - Mappable
-    
-    public func mapping(map: Map) {}
-
     // MARK: - Helpers
 
     private static func customerProfileAction(method: HTTPMethod, basePath: String? = nil,

--- a/Source/Endpoints/Order.swift
+++ b/Source/Endpoints/Order.swift
@@ -7,18 +7,9 @@ import ObjectMapper
 /**
     Provides complete set of interactions for querying, retrieving and creating an order.
 */
-open class Order: QueryEndpoint, ByIdEndpoint, CreateEndpoint, Mappable {
+open class Order: QueryEndpoint, ByIdEndpoint, CreateEndpoint {
     
-    public typealias ResponseType = Order
+    public typealias ResponseType = NoMapping
 
     open static let path = "me/orders"
-    
-    // MARK: - Properties
-    
-    public required init?(map: Map) {}
-    
-    // MARK: - Mappable
-    
-    public func mapping(map: Map) {}
-
 }

--- a/Source/Endpoints/Order.swift
+++ b/Source/Endpoints/Order.swift
@@ -2,13 +2,23 @@
 // Copyright (c) 2016 Commercetools. All rights reserved.
 //
 
-import Foundation
+import ObjectMapper
 
 /**
     Provides complete set of interactions for querying, retrieving and creating an order.
 */
-open class Order: QueryEndpoint, ByIdEndpoint, CreateEndpoint {
+open class Order: QueryEndpoint, ByIdEndpoint, CreateEndpoint, Mappable {
+    
+    public typealias ResponseType = Order
 
     open static let path = "me/orders"
+    
+    // MARK: - Properties
+    
+    public required init?(map: Map) {}
+    
+    // MARK: - Mappable
+    
+    public func mapping(map: Map) {}
 
 }

--- a/Source/Endpoints/ProductProjection.swift
+++ b/Source/Endpoints/ProductProjection.swift
@@ -56,7 +56,7 @@ open class ProductProjection: QueryEndpoint, ByIdEndpoint, Mappable {
                               fuzzy: Bool? = nil, filter: String? = nil, filterQuery: String? = nil, filterFacets: String? = nil,
                               facets: [String]? = nil, priceCurrency: String? = nil, priceCountry: String? = nil,
                               priceCustomerGroup: String? = nil, priceChannel: String? = nil,
-                              result: @escaping (Result<[String: Any]>) -> Void) {
+                              result: @escaping (Result<ResponseType>) -> Void) {
 
         requestWithTokenAndPath(result, { token, path in
             let fullPath = pathWithExpansion("\(path)search", expansion: expansion)
@@ -89,7 +89,7 @@ open class ProductProjection: QueryEndpoint, ByIdEndpoint, Mappable {
         - parameter result:                   The code to be executed after processing the response.
     */
     open static func suggest(staged: Bool? = nil, limit: UInt? = nil, lang: Locale = Locale.current,
-                               searchKeywords: String, fuzzy: Bool? = nil, result: @escaping (Result<[String: Any]>) -> Void) {
+                               searchKeywords: String, fuzzy: Bool? = nil, result: @escaping (Result<ResponseType>) -> Void) {
 
         requestWithTokenAndPath(result, { token, path in
             var parameters = paramsWithStaged(staged, params: queryParameters(limit: limit))
@@ -116,7 +116,7 @@ open class ProductProjection: QueryEndpoint, ByIdEndpoint, Mappable {
         - parameter result:                   The code to be executed after processing the response.
     */
     open static func query(staged: Bool? = nil, predicates: [String]? = nil, sort: [String]? = nil, expansion: [String]? = nil,
-                      limit: UInt? = nil, offset: UInt? = nil, result: @escaping (Result<[String: Any]>) -> Void) {
+                      limit: UInt? = nil, offset: UInt? = nil, result: @escaping (Result<ResponseType>) -> Void) {
 
         requestWithTokenAndPath(result, { token, path in
             let fullPath = pathWithExpansion(path, expansion: expansion)
@@ -139,7 +139,7 @@ open class ProductProjection: QueryEndpoint, ByIdEndpoint, Mappable {
         - parameter expansion:                An optional array of expansion property names.
         - parameter result:                   The code to be executed after processing the response.
     */
-    open static func byId(_ id: String, staged: Bool? = nil, expansion: [String]? = nil, result: @escaping (Result<[String: Any]>) -> Void) {
+    open static func byId(_ id: String, staged: Bool? = nil, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
 
         requestWithTokenAndPath(result, { token, path in
             let fullPath = pathWithExpansion(path + id, expansion: expansion)

--- a/Source/Endpoints/ProductProjection.swift
+++ b/Source/Endpoints/ProductProjection.swift
@@ -2,17 +2,25 @@
 // Copyright (c) 2016 Commercetools. All rights reserved.
 //
 
-import Foundation
 import Alamofire
+import ObjectMapper
 
 /**
     Provides complete set of interactions for querying, retrieving and creating an order.
 */
-open class ProductProjection: QueryEndpoint, ByIdEndpoint {
+open class ProductProjection: QueryEndpoint, ByIdEndpoint, Mappable {
+    
+    public typealias ResponseType = ProductProjection
 
     // MARK: - Properties
 
-    open static let path = "product-projections"
+    open static let path = "product-projections"        
+    
+    public required init?(map: Map) {}
+    
+    // MARK: - Mappable
+    
+    public func mapping(map: Map) {}
 
     // MARK: - Product projection endpoint functionality
 

--- a/Source/Endpoints/ProductProjection.swift
+++ b/Source/Endpoints/ProductProjection.swift
@@ -8,19 +8,13 @@ import ObjectMapper
 /**
     Provides complete set of interactions for querying, retrieving and creating an order.
 */
-open class ProductProjection: QueryEndpoint, ByIdEndpoint, Mappable {
+open class ProductProjection: QueryEndpoint, ByIdEndpoint {
     
-    public typealias ResponseType = ProductProjection
+    public typealias ResponseType = NoMapping
 
     // MARK: - Properties
 
-    open static let path = "product-projections"        
-    
-    public required init?(map: Map) {}
-    
-    // MARK: - Mappable
-    
-    public func mapping(map: Map) {}
+    open static let path = "product-projections"
 
     // MARK: - Product projection endpoint functionality
 

--- a/Source/Endpoints/ProductType.swift
+++ b/Source/Endpoints/ProductType.swift
@@ -7,18 +7,9 @@ import ObjectMapper
 /**
     Provides set of interactions for querying, retrieving by UUID and by key for product types.
 */
-open class ProductType: ByIdEndpoint, ByKeyEndpoint, QueryEndpoint, Mappable {
+open class ProductType: ByIdEndpoint, ByKeyEndpoint, QueryEndpoint {
     
-    public typealias ResponseType = ProductType
+    public typealias ResponseType = NoMapping
 
     open static let path = "product-types"
-    
-    // MARK: - Properties
-    
-    public required init?(map: Map) {}
-    
-    // MARK: - Mappable
-    
-    public func mapping(map: Map) {}
-
 }

--- a/Source/Endpoints/ProductType.swift
+++ b/Source/Endpoints/ProductType.swift
@@ -2,13 +2,23 @@
 // Copyright (c) 2016 Commercetools. All rights reserved.
 //
 
-import Foundation
+import ObjectMapper
 
 /**
     Provides set of interactions for querying, retrieving by UUID and by key for product types.
 */
-open class ProductType: ByIdEndpoint, ByKeyEndpoint, QueryEndpoint {
+open class ProductType: ByIdEndpoint, ByKeyEndpoint, QueryEndpoint, Mappable {
+    
+    public typealias ResponseType = ProductType
 
     open static let path = "product-types"
+    
+    // MARK: - Properties
+    
+    public required init?(map: Map) {}
+    
+    // MARK: - Mappable
+    
+    public func mapping(map: Map) {}
 
 }

--- a/Source/Models/Address.swift
+++ b/Source/Models/Address.swift
@@ -1,0 +1,67 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+
+struct Address: Mappable {
+
+    // MARK: - Properties
+
+    var id: String?
+    var title: String?
+    var salutation: String?
+    var firstName: String?
+    var lastName: String?
+    var city: String?
+    var region: String?
+    var postalCode: String?
+    var streetName: String?
+    var additionalStreetInfo: String?
+    var streetNumber: String?
+    var state: String?
+    var country: String?
+    var company: String?
+    var department: String?
+    var building: String?
+    var apartment: String?
+    var pOBox: String?
+    var phone: String?
+    var mobile: String?
+    var email: String?
+    var fax: String?
+    var additionalAddressInfo: String?
+
+    init?(map: Map) {}
+
+    init() {}
+
+    // MARK: - Mappable
+
+    mutating func mapping(map: Map) {
+        id                      <- map["id"]
+        title                   <- map["title"]
+        salutation              <- map["salutation"]
+        firstName               <- map["firstName"]
+        lastName                <- map["lastName"]
+        city                    <- map["city"]
+        region                  <- map["region"]
+        postalCode              <- map["postalCode"]
+        streetName              <- map["streetName"]
+        additionalStreetInfo    <- map["additionalStreetInfo"]
+        streetNumber            <- map["streetNumber"]
+        state                   <- map["state"]
+        country                 <- map["country"]
+        company                 <- map["company"]
+        department              <- map["department"]
+        building                <- map["building"]
+        apartment               <- map["apartment"]
+        pOBox                   <- map["pOBox"]
+        phone                   <- map["phone"]
+        mobile                  <- map["mobile"]
+        email                   <- map["email"]
+        fax                     <- map["fax"]
+        additionalAddressInfo   <- map["additionalAddressInfo"]
+    }
+
+}

--- a/Source/Models/Address.swift
+++ b/Source/Models/Address.swift
@@ -4,7 +4,7 @@
 
 import ObjectMapper
 
-struct Address: Mappable {
+public struct Address: Mappable {
 
     // MARK: - Properties
 
@@ -32,11 +32,11 @@ struct Address: Mappable {
     var fax: String?
     var additionalAddressInfo: String?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         id                      <- map["id"]
         title                   <- map["title"]
         salutation              <- map["salutation"]

--- a/Source/Models/Address.swift
+++ b/Source/Models/Address.swift
@@ -13,12 +13,12 @@ struct Address: Mappable {
     var salutation: String?
     var firstName: String?
     var lastName: String?
+    var streetName: String?
+    var streetNumber: String?
     var city: String?
     var region: String?
     var postalCode: String?
-    var streetName: String?
     var additionalStreetInfo: String?
-    var streetNumber: String?
     var state: String?
     var country: String?
     var company: String?
@@ -33,8 +33,6 @@ struct Address: Mappable {
     var additionalAddressInfo: String?
 
     init?(map: Map) {}
-
-    init() {}
 
     // MARK: - Mappable
 

--- a/Source/Models/Attribute.swift
+++ b/Source/Models/Attribute.swift
@@ -1,0 +1,23 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+
+struct Attribute: Mappable {
+
+    // MARK: - Properties
+
+    var name: String?
+    var value: AnyObject?
+
+    init?(map: Map) {}
+
+    // MARK: - Mappable
+
+    mutating func mapping(map: Map) {
+        name               <- map["name"]
+        value              <- map["value"]
+    }
+
+}

--- a/Source/Models/Attribute.swift
+++ b/Source/Models/Attribute.swift
@@ -4,18 +4,18 @@
 
 import ObjectMapper
 
-struct Attribute: Mappable {
+public struct Attribute: Mappable {
 
     // MARK: - Properties
 
     var name: String?
     var value: AnyObject?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         name               <- map["name"]
         value              <- map["value"]
     }

--- a/Source/Models/AttributeDefinition.swift
+++ b/Source/Models/AttributeDefinition.swift
@@ -1,0 +1,31 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+
+struct AttributeDefinition: Mappable {
+    
+    // MARK: - Properties
+
+    var type: AttributeType?
+    var name: String?
+    var label: [String: String]?
+    var inputTip: [String: String]?
+    var isRequired: Bool?
+    var isSearchable: Bool?
+    
+    init?(map: Map) {}
+    
+    // MARK: - Mappable
+    
+    mutating func mapping(map: Map) {
+        type               <- map["type"]
+        name               <- map["name"]
+        label              <- map["label"]
+        inputTip           <- map["inputTip"]
+        isRequired         <- map["isRequired"]
+        isSearchable       <- map["isSearchable"]
+    }
+    
+}

--- a/Source/Models/AttributeDefinition.swift
+++ b/Source/Models/AttributeDefinition.swift
@@ -4,7 +4,7 @@
 
 import ObjectMapper
 
-struct AttributeDefinition: Mappable {
+public struct AttributeDefinition: Mappable {
     
     // MARK: - Properties
 
@@ -15,11 +15,11 @@ struct AttributeDefinition: Mappable {
     var isRequired: Bool?
     var isSearchable: Bool?
     
-    init?(map: Map) {}
+    public init?(map: Map) {}
     
     // MARK: - Mappable
     
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         type               <- map["type"]
         name               <- map["name"]
         label              <- map["label"]

--- a/Source/Models/AttributeType.swift
+++ b/Source/Models/AttributeType.swift
@@ -1,0 +1,23 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+
+class AttributeType: Mappable {
+
+    // MARK: - Properties
+
+    var name: String?
+    var elementType: AttributeType?
+
+    required init?(map: Map) {}
+
+    // MARK: - Mappable
+
+    func mapping(map: Map) {
+        name               <- map["name"]
+        elementType        <- map["elementType"]
+    }
+
+}

--- a/Source/Models/AttributeType.swift
+++ b/Source/Models/AttributeType.swift
@@ -11,7 +11,7 @@ class AttributeType: Mappable {
     var name: String?
     var elementType: AttributeType?
 
-    required init?(map: Map) {}
+    required public init?(map: Map) {}
 
     // MARK: - Mappable
 

--- a/Source/Models/CartDiscount.swift
+++ b/Source/Models/CartDiscount.swift
@@ -4,7 +4,7 @@
 
 import ObjectMapper
 
-struct CartDiscount: Mappable {
+public struct CartDiscount: Mappable {
 
     // MARK: - Properties
 
@@ -24,11 +24,11 @@ struct CartDiscount: Mappable {
     var requiresDiscountCode: Bool?
     var references: [GenericReference]?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         id                    <- map["id"]
         version               <- map["version"]
         createdAt             <- (map["createdAt"], ISO8601DateTransform())

--- a/Source/Models/CartDiscount.swift
+++ b/Source/Models/CartDiscount.swift
@@ -1,0 +1,49 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+
+struct CartDiscount: Mappable {
+
+    // MARK: - Properties
+
+    var id: String?
+    var version: UInt?
+    var createdAt: Date?
+    var lastModifiedAt: Date?
+    var name: LocalizedString?
+    var description: LocalizedString?
+    var value: CartDiscountValue?
+    var cartPredicate: String?
+    var target: CartDiscountTarget?
+    var sortOrder: String?
+    var isActive: Bool?
+    var validFrom: Date?
+    var validUntil: Date?
+    var requiresDiscountCode: Bool?
+    var references: [GenericReference]?
+
+    init?(map: Map) {}
+
+    // MARK: - Mappable
+
+    mutating func mapping(map: Map) {
+        id                    <- map["id"]
+        version               <- map["version"]
+        createdAt             <- (map["createdAt"], ISO8601DateTransform())
+        lastModifiedAt        <- (map["lastModifiedAt"], ISO8601DateTransform())
+        name                  <- map["name"]
+        description           <- map["description"]
+        value                 <- map["value"]
+        cartPredicate         <- map["cartPredicate"]
+        target                <- map["target"]
+        sortOrder             <- map["sortOrder"]
+        isActive              <- map["isActive"]
+        validFrom             <- (map["validFrom"], ISO8601DateTransform())
+        validUntil            <- (map["validUntil"], ISO8601DateTransform())
+        requiresDiscountCode  <- map["requiresDiscountCode"]
+        references            <- map["references"]
+    }
+
+}

--- a/Source/Models/CartDiscountTarget.swift
+++ b/Source/Models/CartDiscountTarget.swift
@@ -4,18 +4,18 @@
 
 import ObjectMapper
 
-struct CartDiscountTarget: Mappable {
+public struct CartDiscountTarget: Mappable {
 
     // MARK: - Properties
 
     var type: String?
     var predicate: String?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         type          <- map["type"]
         predicate     <- map["predicate"]
     }

--- a/Source/Models/CartDiscountTarget.swift
+++ b/Source/Models/CartDiscountTarget.swift
@@ -4,19 +4,20 @@
 
 import ObjectMapper
 
-struct Money: Mappable {
+struct CartDiscountTarget: Mappable {
 
     // MARK: - Properties
 
-    var currencyCode: String?
-    var centAmount: Int?
+    var type: String?
+    var predicate: String?
 
     init?(map: Map) {}
 
     // MARK: - Mappable
 
     mutating func mapping(map: Map) {
-        currencyCode       <- map["currencyCode"]
-        centAmount         <- map["centAmount"]
+        type          <- map["type"]
+        predicate     <- map["predicate"]
     }
+
 }

--- a/Source/Models/CartDiscountValue.swift
+++ b/Source/Models/CartDiscountValue.swift
@@ -4,7 +4,7 @@
 
 import ObjectMapper
 
-struct CartDiscountValue: Mappable {
+public struct CartDiscountValue: Mappable {
 
     // MARK: - Properties
 
@@ -12,11 +12,11 @@ struct CartDiscountValue: Mappable {
     var permyriad: Int?
     var money: Money?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         type          <- map["type"]
         permyriad     <- map["permyriad"]
         money         <- map["money"]

--- a/Source/Models/CartDiscountValue.swift
+++ b/Source/Models/CartDiscountValue.swift
@@ -1,0 +1,25 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+
+struct CartDiscountValue: Mappable {
+
+    // MARK: - Properties
+
+    var type: String?
+    var permyriad: Int?
+    var money: Money?
+
+    init?(map: Map) {}
+
+    // MARK: - Mappable
+
+    mutating func mapping(map: Map) {
+        type          <- map["type"]
+        permyriad     <- map["permyriad"]
+        money         <- map["money"]
+    }
+
+}

--- a/Source/Models/CartState.swift
+++ b/Source/Models/CartState.swift
@@ -1,0 +1,13 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import Foundation
+
+enum CartState: String {
+    
+    case active = "Active"
+    case merged = "Merged"
+    case ordered = "Ordered"
+    
+}

--- a/Source/Models/CartState.swift
+++ b/Source/Models/CartState.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-enum CartState: String {
+public enum CartState: String {
     
     case active = "Active"
     case merged = "Merged"

--- a/Source/Models/Channel.swift
+++ b/Source/Models/Channel.swift
@@ -1,0 +1,35 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+
+class Channel: Mappable {
+
+    // MARK: - Properties
+
+    var id: String?
+    var version: UInt?
+    var createdAt: Date?
+    var lastModifiedAt: Date?
+    var key: String?
+    var name: [String: String]?
+    var description: [String: String]?
+    var address: Address?
+
+    required init?(map: Map) {}
+
+    // MARK: - Mappable
+
+    func mapping(map: Map) {
+        id               <- map["id"]
+        version          <- map["version"]
+        createdAt        <- (map["createdAt"], ISO8601DateTransform())
+        lastModifiedAt   <- (map["lastModifiedAt"], ISO8601DateTransform())
+        key              <- map["key"]
+        name             <- map["name"]
+        description      <- map["description"]
+        address          <- map["address"]
+    }
+
+}

--- a/Source/Models/Channel.swift
+++ b/Source/Models/Channel.swift
@@ -20,7 +20,7 @@ class Channel: Mappable {
     var reviewRatingStatistics: ReviewRatingStatistics?
     var custom: [String: Any]?
 
-    required init?(map: Map) {}
+    required public init?(map: Map) {}
 
     // MARK: - Mappable
 

--- a/Source/Models/Channel.swift
+++ b/Source/Models/Channel.swift
@@ -13,23 +13,29 @@ class Channel: Mappable {
     var createdAt: Date?
     var lastModifiedAt: Date?
     var key: String?
-    var name: [String: String]?
-    var description: [String: String]?
+    var roles: [ChannelRole]?
+    var name: LocalizedString?
+    var description: LocalizedString?
     var address: Address?
+    var reviewRatingStatistics: ReviewRatingStatistics?
+    var custom: [String: Any]?
 
     required init?(map: Map) {}
 
     // MARK: - Mappable
 
     func mapping(map: Map) {
-        id               <- map["id"]
-        version          <- map["version"]
-        createdAt        <- (map["createdAt"], ISO8601DateTransform())
-        lastModifiedAt   <- (map["lastModifiedAt"], ISO8601DateTransform())
-        key              <- map["key"]
-        name             <- map["name"]
-        description      <- map["description"]
-        address          <- map["address"]
+        id                      <- map["id"]
+        version                 <- map["version"]
+        createdAt               <- (map["createdAt"], ISO8601DateTransform())
+        lastModifiedAt          <- (map["lastModifiedAt"], ISO8601DateTransform())
+        key                     <- map["key"]
+        roles                   <- map["roles"]
+        name                    <- map["name"]
+        description             <- map["description"]
+        address                 <- map["address"]
+        reviewRatingStatistics  <- map["reviewRatingStatistics"]
+        custom                  <- map["custom"]
     }
 
 }

--- a/Source/Models/ChannelRole.swift
+++ b/Source/Models/ChannelRole.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-enum ChannelRole: String {
+public enum ChannelRole: String {
 
     case inventorySupply = "InventorySupply"
     case productDistribution = "ProductDistribution"

--- a/Source/Models/ChannelRole.swift
+++ b/Source/Models/ChannelRole.swift
@@ -1,0 +1,15 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import Foundation
+
+enum ChannelRole: String {
+
+    case inventorySupply = "InventorySupply"
+    case productDistribution = "ProductDistribution"
+    case orderExport =  "OrderExport"
+    case orderImport = "OrderImport"
+    case primary = "Primary"
+
+}

--- a/Source/Models/CustomLineItem.swift
+++ b/Source/Models/CustomLineItem.swift
@@ -4,7 +4,7 @@
 
 import ObjectMapper
 
-struct CustomLineItem: Mappable {
+public struct CustomLineItem: Mappable {
     
     // MARK: - Properties
     
@@ -21,11 +21,11 @@ struct CustomLineItem: Mappable {
     var discountedPricePerQuantity: [DiscountedLineItemPriceForQuantity]?
     var custom: [String: Any]?    
     
-    init?(map: Map) {}
+    public init?(map: Map) {}
     
     // MARK: - Mappable
     
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         id                          <- map["id"]
         name                        <- map["name"]
         money                       <- map["money"]

--- a/Source/Models/CustomLineItem.swift
+++ b/Source/Models/CustomLineItem.swift
@@ -1,0 +1,43 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+
+struct CustomLineItem: Mappable {
+    
+    // MARK: - Properties
+    
+    var id: String?
+    var name: LocalizedString?
+    var money: Money?
+    var taxedPrice: TaxedItemPrice?
+    var totalPrice: Money?
+    var slug: String?
+    var quantity: Int?
+    var state: ItemState?
+    var taxCategory: Reference<TaxCategory>?
+    var taxRate: TaxRate?
+    var discountedPricePerQuantity: [DiscountedLineItemPriceForQuantity]?
+    var custom: [String: Any]?    
+    
+    init?(map: Map) {}
+    
+    // MARK: - Mappable
+    
+    mutating func mapping(map: Map) {
+        id                          <- map["id"]
+        name                        <- map["name"]
+        money                       <- map["money"]
+        taxedPrice                  <- map["taxedPrice"]
+        totalPrice                  <- map["totalPrice"]
+        slug                        <- map["slug"]
+        quantity                    <- map["quantity"]
+        state                       <- map["state"]
+        taxCategory                 <- map["taxCategory"]
+        taxRate                     <- map["taxRate"]
+        discountedPricePerQuantity  <- map["discountedPricePerQuantity"]
+        custom                      <- map["custom"]
+    }
+    
+}

--- a/Source/Models/CustomerGroup.swift
+++ b/Source/Models/CustomerGroup.swift
@@ -1,0 +1,29 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+
+struct CustomerGroup: Mappable {
+    
+    // MARK: - Properties
+    
+    var id: String?
+    var version: UInt?
+    var createdAt: Date?
+    var lastModifiedAt: Date?
+    var name: String?
+    
+    init?(map: Map) {}
+    
+    // MARK: - Mappable
+    
+    mutating func mapping(map: Map) {
+        id               <- map["id"]
+        version          <- map["version"]
+        createdAt        <- (map["createdAt"], ISO8601DateTransform())
+        lastModifiedAt   <- (map["lastModifiedAt"], ISO8601DateTransform())
+        name             <- map["name"]
+    }
+    
+}

--- a/Source/Models/CustomerGroup.swift
+++ b/Source/Models/CustomerGroup.swift
@@ -4,7 +4,7 @@
 
 import ObjectMapper
 
-struct CustomerGroup: Mappable {
+public struct CustomerGroup: Mappable {
     
     // MARK: - Properties
     
@@ -14,11 +14,11 @@ struct CustomerGroup: Mappable {
     var lastModifiedAt: Date?
     var name: String?
     
-    init?(map: Map) {}
+    public init?(map: Map) {}
     
     // MARK: - Mappable
     
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         id               <- map["id"]
         version          <- map["version"]
         createdAt        <- (map["createdAt"], ISO8601DateTransform())

--- a/Source/Models/Delivery.swift
+++ b/Source/Models/Delivery.swift
@@ -4,7 +4,7 @@
 
 import ObjectMapper
 
-struct Delivery: Mappable {
+public struct Delivery: Mappable {
 
     // MARK: - Properties
 
@@ -13,11 +13,11 @@ struct Delivery: Mappable {
     var items: [DeliveryItem]?
     var parcels: [Parcel]?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         id                <- map["id"]
         createdAt         <- (map["createdAt"], ISO8601DateTransform())
         items             <- map["items"]

--- a/Source/Models/Delivery.swift
+++ b/Source/Models/Delivery.swift
@@ -1,0 +1,27 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+
+struct Delivery: Mappable {
+
+    // MARK: - Properties
+
+    var id: String?
+    var createdAt: Date?
+    var items: [DeliveryItem]?
+    var parcels: [Parcel]?
+
+    init?(map: Map) {}
+
+    // MARK: - Mappable
+
+    mutating func mapping(map: Map) {
+        id                <- map["id"]
+        createdAt         <- (map["createdAt"], ISO8601DateTransform())
+        items             <- map["items"]
+        parcels           <- map["parcels"]
+    }
+
+}

--- a/Source/Models/DeliveryItem.swift
+++ b/Source/Models/DeliveryItem.swift
@@ -4,19 +4,20 @@
 
 import ObjectMapper
 
-struct Money: Mappable {
+struct DeliveryItem: Mappable {
 
     // MARK: - Properties
 
-    var currencyCode: String?
-    var centAmount: Int?
+    var id: String?
+    var quantity: Int?
 
     init?(map: Map) {}
 
     // MARK: - Mappable
 
     mutating func mapping(map: Map) {
-        currencyCode       <- map["currencyCode"]
-        centAmount         <- map["centAmount"]
+        id                <- map["id"]
+        quantity          <- map["quantity"]
     }
+
 }

--- a/Source/Models/DeliveryItem.swift
+++ b/Source/Models/DeliveryItem.swift
@@ -4,18 +4,18 @@
 
 import ObjectMapper
 
-struct DeliveryItem: Mappable {
+public struct DeliveryItem: Mappable {
 
     // MARK: - Properties
 
     var id: String?
     var quantity: Int?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         id                <- map["id"]
         quantity          <- map["quantity"]
     }

--- a/Source/Models/DiscountCode.swift
+++ b/Source/Models/DiscountCode.swift
@@ -4,7 +4,7 @@
 
 import ObjectMapper
 
-struct DiscountCode: Mappable {
+public struct DiscountCode: Mappable {
     
     // MARK: - Properties
     
@@ -22,11 +22,11 @@ struct DiscountCode: Mappable {
     var maxApplications: Int?
     var maxApplicationsPerCustomer: Int?
     
-    init?(map: Map) {}
+    public init?(map: Map) {}
     
     // MARK: - Mappable
     
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         id                           <- map["id"]
         version                      <- map["version"]
         createdAt                    <- (map["createdAt"], ISO8601DateTransform())

--- a/Source/Models/DiscountCode.swift
+++ b/Source/Models/DiscountCode.swift
@@ -1,0 +1,45 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+
+struct DiscountCode: Mappable {
+    
+    // MARK: - Properties
+    
+    var id: String?
+    var version: UInt?
+    var createdAt: Date?
+    var lastModifiedAt: Date?
+    var name: LocalizedString?
+    var description: LocalizedString?
+    var code: String?
+    var cartDiscounts: [CartDiscount]?
+    var cartPredicate: String?
+    var isActive: Bool?
+    var references: [GenericReference]?
+    var maxApplications: Int?
+    var maxApplicationsPerCustomer: Int?
+    
+    init?(map: Map) {}
+    
+    // MARK: - Mappable
+    
+    mutating func mapping(map: Map) {
+        id                           <- map["id"]
+        version                      <- map["version"]
+        createdAt                    <- (map["createdAt"], ISO8601DateTransform())
+        lastModifiedAt               <- (map["lastModifiedAt"], ISO8601DateTransform())
+        name                         <- map["name"]
+        description                  <- map["description"]
+        code                         <- map["code"]
+        cartDiscounts                <- map["cartDiscounts"]
+        cartPredicate                <- map["cartPredicate"]
+        isActive                     <- map["isActive"]
+        references                   <- map["references"]
+        maxApplications              <- map["maxApplications"]
+        maxApplicationsPerCustomer   <- map["maxApplicationsPerCustomer"]
+    }
+    
+}

--- a/Source/Models/DiscountCodeInfo.swift
+++ b/Source/Models/DiscountCodeInfo.swift
@@ -4,18 +4,18 @@
 
 import ObjectMapper
 
-struct DiscountCodeInfo: Mappable {
+public struct DiscountCodeInfo: Mappable {
     
     // MARK: - Properties
     
     var discountCode: Reference<DiscountCode>?
     var state: DiscountCodeState?
     
-    init?(map: Map) {}
+    public init?(map: Map) {}
     
     // MARK: - Mappable
     
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         discountCode           <- map["discountCode"]
         state                  <- map["state"]
     }

--- a/Source/Models/DiscountCodeInfo.swift
+++ b/Source/Models/DiscountCodeInfo.swift
@@ -1,0 +1,23 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+
+struct DiscountCodeInfo: Mappable {
+    
+    // MARK: - Properties
+    
+    var discountCode: Reference<DiscountCode>?
+    var state: DiscountCodeState?
+    
+    init?(map: Map) {}
+    
+    // MARK: - Mappable
+    
+    mutating func mapping(map: Map) {
+        discountCode           <- map["discountCode"]
+        state                  <- map["state"]
+    }
+    
+}

--- a/Source/Models/DiscountCodeState.swift
+++ b/Source/Models/DiscountCodeState.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-enum DiscountCodeState: String {
+public enum DiscountCodeState: String {
     
     case notActive = "NotActive"
     case doesNotMatchCart = "DoesNotMatchCart"

--- a/Source/Models/DiscountCodeState.swift
+++ b/Source/Models/DiscountCodeState.swift
@@ -1,0 +1,14 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import Foundation
+
+enum DiscountCodeState: String {
+    
+    case notActive = "NotActive"
+    case doesNotMatchCart = "DoesNotMatchCart"
+    case matchesCart = "MatchesCart"
+    case maxApplicationReached = "MaxApplicationReached"
+    
+}

--- a/Source/Models/DiscountedLineItemPortion.swift
+++ b/Source/Models/DiscountedLineItemPortion.swift
@@ -4,18 +4,18 @@
 
 import ObjectMapper
 
-struct DiscountedLineItemPortion: Mappable {
+public struct DiscountedLineItemPortion: Mappable {
 
     // MARK: - Properties
 
     var discount: Reference<CartDiscount>?
     var discountedAmount: Money?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         discount          <- map["discount"]
         discountedAmount  <- map["discountedAmount"]
     }

--- a/Source/Models/DiscountedLineItemPortion.swift
+++ b/Source/Models/DiscountedLineItemPortion.swift
@@ -1,0 +1,23 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+
+struct DiscountedLineItemPortion: Mappable {
+
+    // MARK: - Properties
+
+    var discount: Reference<CartDiscount>?
+    var discountedAmount: Money?
+
+    init?(map: Map) {}
+
+    // MARK: - Mappable
+
+    mutating func mapping(map: Map) {
+        discount          <- map["discount"]
+        discountedAmount  <- map["discountedAmount"]
+    }
+
+}

--- a/Source/Models/DiscountedLineItemPrice.swift
+++ b/Source/Models/DiscountedLineItemPrice.swift
@@ -4,18 +4,18 @@
 
 import ObjectMapper
 
-struct DiscountedLineItemPrice: Mappable {
+public struct DiscountedLineItemPrice: Mappable {
 
     // MARK: - Properties
 
     var value: Money?
     var includedDiscounts: [DiscountedLineItemPortion]?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         value             <- map["value"]
         includedDiscounts <- map["includedDiscounts"]
     }

--- a/Source/Models/DiscountedLineItemPrice.swift
+++ b/Source/Models/DiscountedLineItemPrice.swift
@@ -9,7 +9,7 @@ struct DiscountedLineItemPrice: Mappable {
     // MARK: - Properties
 
     var value: Money?
-    var includedDiscounts: [String: AnyObject]?
+    var includedDiscounts: [DiscountedLineItemPortion]?
 
     init?(map: Map) {}
 

--- a/Source/Models/DiscountedLineItemPrice.swift
+++ b/Source/Models/DiscountedLineItemPrice.swift
@@ -1,0 +1,23 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+
+struct DiscountedLineItemPrice: Mappable {
+
+    // MARK: - Properties
+
+    var value: Money?
+    var includedDiscounts: [String: AnyObject]?
+
+    init?(map: Map) {}
+
+    // MARK: - Mappable
+
+    mutating func mapping(map: Map) {
+        value             <- map["value"]
+        includedDiscounts <- map["includedDiscounts"]
+    }
+
+}

--- a/Source/Models/DiscountedLineItemPriceForQuantity.swift
+++ b/Source/Models/DiscountedLineItemPriceForQuantity.swift
@@ -1,0 +1,23 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+
+struct DiscountedLineItemPriceForQuantity: Mappable {
+
+    // MARK: - Properties
+
+    var quantity: Int?
+    var discountedPrice: DiscountedLineItemPrice?
+
+    init?(map: Map) {}
+
+    // MARK: - Mappable
+
+    mutating func mapping(map: Map) {
+        quantity         <- map["quantity"]
+        discountedPrice  <- map["discountedPrice"]
+    }
+
+}

--- a/Source/Models/DiscountedLineItemPriceForQuantity.swift
+++ b/Source/Models/DiscountedLineItemPriceForQuantity.swift
@@ -4,18 +4,18 @@
 
 import ObjectMapper
 
-struct DiscountedLineItemPriceForQuantity: Mappable {
+public struct DiscountedLineItemPriceForQuantity: Mappable {
 
     // MARK: - Properties
 
     var quantity: Int?
     var discountedPrice: DiscountedLineItemPrice?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         quantity         <- map["quantity"]
         discountedPrice  <- map["discountedPrice"]
     }

--- a/Source/Models/DiscountedPrice.swift
+++ b/Source/Models/DiscountedPrice.swift
@@ -1,0 +1,23 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+
+struct DiscountedPrice: Mappable {
+
+    // MARK: - Properties
+
+    var value: Money?
+    var discount: [String: AnyObject]?
+
+    init?(map: Map) {}
+
+    // MARK: - Mappable
+
+    mutating func mapping(map: Map) {
+        value              <- map["value"]
+        discount           <- map["discount"]
+    }
+
+}

--- a/Source/Models/DiscountedPrice.swift
+++ b/Source/Models/DiscountedPrice.swift
@@ -4,18 +4,18 @@
 
 import ObjectMapper
 
-struct DiscountedPrice: Mappable {
+public struct DiscountedPrice: Mappable {
 
     // MARK: - Properties
 
     var value: Money?
     var discount: [String: AnyObject]?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         value              <- map["value"]
         discount           <- map["discount"]
     }

--- a/Source/Models/Image.swift
+++ b/Source/Models/Image.swift
@@ -4,7 +4,7 @@
 
 import ObjectMapper
 
-struct Image: Mappable {
+public struct Image: Mappable {
 
     // MARK: - Properties
 
@@ -12,11 +12,11 @@ struct Image: Mappable {
     var dimensions: [String: Int]?
     var label: String?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         url                <- map["url"]
         dimensions         <- map["dimensions"]
         label              <- map["label"]

--- a/Source/Models/Image.swift
+++ b/Source/Models/Image.swift
@@ -1,0 +1,25 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+
+struct Image: Mappable {
+
+    // MARK: - Properties
+
+    var url: String?
+    var dimensions: [String: Int]?
+    var label: String?
+
+    init?(map: Map) {}
+
+    // MARK: - Mappable
+
+    mutating func mapping(map: Map) {
+        url                <- map["url"]
+        dimensions         <- map["dimensions"]
+        label              <- map["label"]
+    }
+
+}

--- a/Source/Models/InventoryMode.swift
+++ b/Source/Models/InventoryMode.swift
@@ -1,0 +1,13 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import Foundation
+
+enum InventoryMode: String {
+    
+    case trackOnly = "TrackOnly"
+    case reserveOnOrder = "ReserveOnOrder"
+    case none = "None"
+    
+}

--- a/Source/Models/InventoryMode.swift
+++ b/Source/Models/InventoryMode.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-enum InventoryMode: String {
+public enum InventoryMode: String {
     
     case trackOnly = "TrackOnly"
     case reserveOnOrder = "ReserveOnOrder"

--- a/Source/Models/ItemState.swift
+++ b/Source/Models/ItemState.swift
@@ -4,18 +4,18 @@
 
 import ObjectMapper
 
-struct ItemState: Mappable {
+public struct ItemState: Mappable {
 
     // MARK: - Properties
 
     var quantity: Int?
     var state: Reference<State>?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         quantity                <- map["quantity"]
         state                   <- map["state"]
     }

--- a/Source/Models/ItemState.swift
+++ b/Source/Models/ItemState.swift
@@ -4,19 +4,20 @@
 
 import ObjectMapper
 
-struct Money: Mappable {
+struct ItemState: Mappable {
 
     // MARK: - Properties
 
-    var currencyCode: String?
-    var centAmount: Int?
+    var quantity: Int?
+    var state: Reference<State>?
 
     init?(map: Map) {}
 
     // MARK: - Mappable
 
     mutating func mapping(map: Map) {
-        currencyCode       <- map["currencyCode"]
-        centAmount         <- map["centAmount"]
+        quantity                <- map["quantity"]
+        state                   <- map["state"]
     }
+
 }

--- a/Source/Models/LineItem.swift
+++ b/Source/Models/LineItem.swift
@@ -4,20 +4,28 @@
 
 import ObjectMapper
 
+public typealias LocalizedString = [String: String]
+
 struct LineItem: Mappable {
     
     // MARK: - Properties
     
     var id: String?
     var productId: String?
-    var name: [String: String]?
-    var productSlug: [String: String]?
+    var name: LocalizedString?
+    var productSlug: LocalizedString?
     var variant: ProductVariant?
     var price: Price?
+    var taxedPrice: TaxedItemPrice?
     var totalPrice: Money?
-    var discountedPricePerQuantity: [DiscountedLineItemPriceForQuantity]?
     var quantity: Int?
-    var distributionChannel: Channel?
+    var state: [ItemState]?
+    var taxRate: TaxRate?
+    var supplyChannel: Reference<Channel>?
+    var distributionChannel: Reference<Channel>?
+    var discountedPricePerQuantity: [DiscountedLineItemPriceForQuantity]?
+    var priceMode: LineItemPriceMode?
+    var custom: [String: Any]?
     
     init?(map: Map) {}
     

--- a/Source/Models/LineItem.swift
+++ b/Source/Models/LineItem.swift
@@ -1,0 +1,39 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+
+struct LineItem: Mappable {
+    
+    // MARK: - Properties
+    
+    var id: String?
+    var productId: String?
+    var name: [String: String]?
+    var productSlug: [String: String]?
+    var variant: ProductVariant?
+    var price: Price?
+    var totalPrice: Money?
+    var discountedPricePerQuantity: [DiscountedLineItemPriceForQuantity]?
+    var quantity: Int?
+    var distributionChannel: Channel?
+    
+    init?(map: Map) {}
+    
+    // MARK: - Mappable
+    
+    mutating func mapping(map: Map) {
+        id                         <- map["id"]
+        productId                  <- map["productId"]
+        name                       <- map["name"]
+        productSlug                <- map["productSlug"]
+        variant                    <- map["variant"]
+        price                      <- map["price"]
+        totalPrice                 <- map["totalPrice"]
+        discountedPricePerQuantity <- map["discountedPricePerQuantity"]
+        quantity                   <- map["quantity"]
+        distributionChannel        <- map["distributionChannel.obj"]
+    }
+    
+}

--- a/Source/Models/LineItem.swift
+++ b/Source/Models/LineItem.swift
@@ -6,7 +6,7 @@ import ObjectMapper
 
 public typealias LocalizedString = [String: String]
 
-struct LineItem: Mappable {
+public struct LineItem: Mappable {
     
     // MARK: - Properties
     
@@ -27,11 +27,11 @@ struct LineItem: Mappable {
     var priceMode: LineItemPriceMode?
     var custom: [String: Any]?
     
-    init?(map: Map) {}
+    public init?(map: Map) {}
     
     // MARK: - Mappable
     
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         id                         <- map["id"]
         productId                  <- map["productId"]
         name                       <- map["name"]

--- a/Source/Models/LineItemPriceMode.swift
+++ b/Source/Models/LineItemPriceMode.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-enum LineItemPriceMode: String {
+public enum LineItemPriceMode: String {
 
     case platform = "Platform"
     case externalTotal = "ExternalTotal"

--- a/Source/Models/LineItemPriceMode.swift
+++ b/Source/Models/LineItemPriceMode.swift
@@ -1,0 +1,12 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import Foundation
+
+enum LineItemPriceMode: String {
+
+    case platform = "Platform"
+    case externalTotal = "ExternalTotal"
+
+}

--- a/Source/Models/Location.swift
+++ b/Source/Models/Location.swift
@@ -4,19 +4,20 @@
 
 import ObjectMapper
 
-struct Money: Mappable {
+struct Location: Mappable {
 
     // MARK: - Properties
 
-    var currencyCode: String?
-    var centAmount: Int?
+    var country: String?
+    var state: String?
 
     init?(map: Map) {}
 
     // MARK: - Mappable
 
     mutating func mapping(map: Map) {
-        currencyCode       <- map["currencyCode"]
-        centAmount         <- map["centAmount"]
+        country           <- map["country"]
+        state             <- map["state"]
     }
+
 }

--- a/Source/Models/Location.swift
+++ b/Source/Models/Location.swift
@@ -4,18 +4,18 @@
 
 import ObjectMapper
 
-struct Location: Mappable {
+public struct Location: Mappable {
 
     // MARK: - Properties
 
     var country: String?
     var state: String?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         country           <- map["country"]
         state             <- map["state"]
     }

--- a/Source/Models/Money.swift
+++ b/Source/Models/Money.swift
@@ -4,18 +4,18 @@
 
 import ObjectMapper
 
-struct Money: Mappable {
+public struct Money: Mappable {
 
     // MARK: - Properties
 
     var currencyCode: String?
     var centAmount: Int?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         currencyCode       <- map["currencyCode"]
         centAmount         <- map["centAmount"]
     }

--- a/Source/Models/Money.swift
+++ b/Source/Models/Money.swift
@@ -1,0 +1,27 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+
+struct Money: Mappable {
+
+    // MARK: - Properties
+
+    var currencyCode: String?
+    var centAmount: Int?
+
+    init?(map: Map) {}
+
+    init(currencyCode: String? = nil, centAmount: Int? = nil) {
+        self.currencyCode = currencyCode
+        self.centAmount = centAmount
+    }
+
+    // MARK: - Mappable
+
+    mutating func mapping(map: Map) {
+        currencyCode       <- map["currencyCode"]
+        centAmount         <- map["centAmount"]
+    }
+}

--- a/Source/Models/Parcel.swift
+++ b/Source/Models/Parcel.swift
@@ -4,7 +4,7 @@
 
 import ObjectMapper
 
-struct Parcel: Mappable {
+public struct Parcel: Mappable {
 
     // MARK: - Properties
 
@@ -13,11 +13,11 @@ struct Parcel: Mappable {
     var measurements: ParcelMeasurements?
     var trackingData: TrackingData?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         id                <- map["id"]
         createdAt         <- (map["createdAt"], ISO8601DateTransform())
         measurements      <- map["measurements"]

--- a/Source/Models/Parcel.swift
+++ b/Source/Models/Parcel.swift
@@ -1,0 +1,27 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+
+struct Parcel: Mappable {
+
+    // MARK: - Properties
+
+    var id: String?
+    var createdAt: Date?
+    var measurements: ParcelMeasurements?
+    var trackingData: TrackingData?
+
+    init?(map: Map) {}
+
+    // MARK: - Mappable
+
+    mutating func mapping(map: Map) {
+        id                <- map["id"]
+        createdAt         <- (map["createdAt"], ISO8601DateTransform())
+        measurements      <- map["measurements"]
+        trackingData      <- map["trackingData"]
+    }
+
+}

--- a/Source/Models/ParcelMeasurements.swift
+++ b/Source/Models/ParcelMeasurements.swift
@@ -1,0 +1,27 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+
+struct ParcelMeasurements: Mappable {
+
+    // MARK: - Properties
+
+    var heightInMillimeter: Double?
+    var lengthInMillimeter: Double?
+    var widthInMillimeter: Double?
+    var weightInGram: Double?
+
+    init?(map: Map) {}
+
+    // MARK: - Mappable
+
+    mutating func mapping(map: Map) {
+        heightInMillimeter   <- map["heightInMillimeter"]
+        lengthInMillimeter   <- map["lengthInMillimeter"]
+        widthInMillimeter    <- map["widthInMillimeter"]
+        weightInGram         <- map["weightInGram"]
+    }
+
+}

--- a/Source/Models/ParcelMeasurements.swift
+++ b/Source/Models/ParcelMeasurements.swift
@@ -4,7 +4,7 @@
 
 import ObjectMapper
 
-struct ParcelMeasurements: Mappable {
+public struct ParcelMeasurements: Mappable {
 
     // MARK: - Properties
 
@@ -13,11 +13,11 @@ struct ParcelMeasurements: Mappable {
     var widthInMillimeter: Double?
     var weightInGram: Double?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         heightInMillimeter   <- map["heightInMillimeter"]
         lengthInMillimeter   <- map["lengthInMillimeter"]
         widthInMillimeter    <- map["widthInMillimeter"]

--- a/Source/Models/Payment.swift
+++ b/Source/Models/Payment.swift
@@ -4,7 +4,7 @@
 
 import ObjectMapper
 
-struct Payment: Mappable {
+public struct Payment: Mappable {
 
     // MARK: - Properties
 
@@ -26,11 +26,11 @@ struct Payment: Mappable {
     var createdAt: Date?
     var lastModifiedAt: Date?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         id                    <- map["id"]
         version               <- map["version"]
         customer              <- map["customer"]

--- a/Source/Models/Payment.swift
+++ b/Source/Models/Payment.swift
@@ -1,0 +1,53 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+
+struct Payment: Mappable {
+
+    // MARK: - Properties
+
+    var id: String?
+    var version: UInt?
+    var customer: Reference<Customer>?
+    var externalId: String?
+    var interfaceId: String?
+    var amountPlanned: Money?
+    var amountAuthorized: Money?
+    var authorizedUntil: String?
+    var amountPaid: Money?
+    var amountRefunded: Money?
+    var paymentMethodInfo: PaymentMethodInfo?
+    var paymentStatus: PaymentStatus?
+    var transactions: [Transaction]?
+    var interfaceInteractions: [[String: Any]]?
+    var custom: [String: Any]?
+    var createdAt: Date?
+    var lastModifiedAt: Date?
+
+    init?(map: Map) {}
+
+    // MARK: - Mappable
+
+    mutating func mapping(map: Map) {
+        id                    <- map["id"]
+        version               <- map["version"]
+        customer              <- map["customer"]
+        externalId            <- map["externalId"]
+        interfaceId           <- map["interfaceId"]
+        amountPlanned         <- map["amountPlanned"]
+        amountAuthorized      <- map["amountAuthorized"]
+        authorizedUntil       <- map["authorizedUntil"]
+        amountPaid            <- map["amountPaid"]
+        amountRefunded        <- map["amountRefunded"]
+        paymentMethodInfo     <- map["paymentMethodInfo"]
+        paymentStatus         <- map["paymentStatus"]
+        transactions          <- map["transactions"]
+        interfaceInteractions <- map["interfaceInteractions"]
+        custom                <- map["custom"]
+        createdAt             <- (map["createdAt"], ISO8601DateTransform())
+        lastModifiedAt        <- (map["lastModifiedAt"], ISO8601DateTransform())
+    }
+
+}

--- a/Source/Models/PaymentInfo.swift
+++ b/Source/Models/PaymentInfo.swift
@@ -4,19 +4,18 @@
 
 import ObjectMapper
 
-struct Money: Mappable {
+struct PaymentInfo: Mappable {
 
     // MARK: - Properties
 
-    var currencyCode: String?
-    var centAmount: Int?
+    var payments: [Reference<Payment>]?
 
     init?(map: Map) {}
 
     // MARK: - Mappable
 
     mutating func mapping(map: Map) {
-        currencyCode       <- map["currencyCode"]
-        centAmount         <- map["centAmount"]
+        payments           <- map["payments"]
     }
+
 }

--- a/Source/Models/PaymentInfo.swift
+++ b/Source/Models/PaymentInfo.swift
@@ -4,17 +4,17 @@
 
 import ObjectMapper
 
-struct PaymentInfo: Mappable {
+public struct PaymentInfo: Mappable {
 
     // MARK: - Properties
 
     var payments: [Reference<Payment>]?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         payments           <- map["payments"]
     }
 

--- a/Source/Models/PaymentMethodInfo.swift
+++ b/Source/Models/PaymentMethodInfo.swift
@@ -4,7 +4,7 @@
 
 import ObjectMapper
 
-struct PaymentMethodInfo: Mappable {
+public struct PaymentMethodInfo: Mappable {
 
     // MARK: - Properties
 
@@ -12,11 +12,11 @@ struct PaymentMethodInfo: Mappable {
     var method: String?
     var name: LocalizedString?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         paymentInterface      <- map["paymentInterface"]
         method                <- map["method"]
         name                  <- map["name"]

--- a/Source/Models/PaymentMethodInfo.swift
+++ b/Source/Models/PaymentMethodInfo.swift
@@ -1,0 +1,25 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+
+struct PaymentMethodInfo: Mappable {
+
+    // MARK: - Properties
+
+    var paymentInterface: String?
+    var method: String?
+    var name: LocalizedString?
+
+    init?(map: Map) {}
+
+    // MARK: - Mappable
+
+    mutating func mapping(map: Map) {
+        paymentInterface      <- map["paymentInterface"]
+        method                <- map["method"]
+        name                  <- map["name"]
+    }
+
+}

--- a/Source/Models/PaymentStatus.swift
+++ b/Source/Models/PaymentStatus.swift
@@ -4,7 +4,7 @@
 
 import ObjectMapper
 
-struct PaymentStatus: Mappable {
+public struct PaymentStatus: Mappable {
 
     // MARK: - Properties
 
@@ -12,11 +12,11 @@ struct PaymentStatus: Mappable {
     var interfaceText: String?
     var state: Reference<State>?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         interfaceCode      <- map["interfaceCode"]
         interfaceText      <- map["interfaceText"]
         state              <- map["state"]

--- a/Source/Models/PaymentStatus.swift
+++ b/Source/Models/PaymentStatus.swift
@@ -1,0 +1,25 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+
+struct PaymentStatus: Mappable {
+
+    // MARK: - Properties
+
+    var interfaceCode: String?
+    var interfaceText: String?
+    var state: Reference<State>?
+
+    init?(map: Map) {}
+
+    // MARK: - Mappable
+
+    mutating func mapping(map: Map) {
+        interfaceCode      <- map["interfaceCode"]
+        interfaceText      <- map["interfaceText"]
+        state              <- map["state"]
+    }
+
+}

--- a/Source/Models/Price.swift
+++ b/Source/Models/Price.swift
@@ -4,7 +4,7 @@
 
 import ObjectMapper
 
-struct Price: Mappable {
+public struct Price: Mappable {
 
     // MARK: - Properties
 
@@ -16,11 +16,11 @@ struct Price: Mappable {
     var validUntil: Date?
     var discounted: DiscountedPrice?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         value              <- map["value"]
         country            <- map["country"]
         customerGroup      <- map["customerGroup"]

--- a/Source/Models/Price.swift
+++ b/Source/Models/Price.swift
@@ -1,0 +1,33 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+
+struct Price: Mappable {
+
+    // MARK: - Properties
+
+    var value: Money?
+    var country: String?
+    var customerGroup: [String: AnyObject]?
+    var channel: Channel?
+    var validFrom: Date?
+    var validUntil: Date?
+    var discounted: DiscountedPrice?
+
+    init?(map: Map) {}
+
+    // MARK: - Mappable
+
+    mutating func mapping(map: Map) {
+        value              <- map["value"]
+        country            <- map["country"]
+        customerGroup      <- map["customerGroup"]
+        channel            <- map["channel"]
+        validFrom          <- (map["validFrom"], ISO8601DateTransform())
+        validUntil         <- (map["validUntil"], ISO8601DateTransform())
+        discounted         <- map["discounted"]
+    }
+
+}

--- a/Source/Models/ProductVariant.swift
+++ b/Source/Models/ProductVariant.swift
@@ -1,0 +1,33 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+
+struct ProductVariant: Mappable {
+
+    // MARK: - Properties
+
+    var id: Int?
+    var sku: String?
+    var prices: [Price]?
+    var attributes: [Attribute]?
+    var images: [Image]?
+    var availability: ProductVariantAvailability?
+    var isMatchingVariant: Bool?
+
+    init?(map: Map) {}
+
+    // MARK: - Mappable
+
+    mutating func mapping(map: Map) {
+        id                 <- map["id"]
+        sku                <- map["sku"]
+        prices             <- map["prices"]
+        attributes         <- map["attributes"]
+        images             <- map["images"]
+        availability       <- map["availability"]
+        isMatchingVariant  <- map["isMatchingVariant"]
+    }
+
+}

--- a/Source/Models/ProductVariant.swift
+++ b/Source/Models/ProductVariant.swift
@@ -4,7 +4,7 @@
 
 import ObjectMapper
 
-struct ProductVariant: Mappable {
+public struct ProductVariant: Mappable {
 
     // MARK: - Properties
 
@@ -16,11 +16,11 @@ struct ProductVariant: Mappable {
     var availability: ProductVariantAvailability?
     var isMatchingVariant: Bool?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         id                 <- map["id"]
         sku                <- map["sku"]
         prices             <- map["prices"]

--- a/Source/Models/ProductVariantAvailability.swift
+++ b/Source/Models/ProductVariantAvailability.swift
@@ -1,0 +1,29 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+
+struct ProductVariantAvailability: Mappable {
+
+    // MARK: - Properties
+
+    var isOnStock: Bool?
+    var restockableInDays: Int?
+    var availableQuantity: Int?
+    var channels: [String: ProductVariantAvailability]?
+
+    init?(map: Map) {}
+
+    // MARK: - Mappable
+
+    mutating func mapping(map: Map) {
+        isOnStock                <- map["isOnStock"]
+        restockableInDays        <- map["restockableInDays"]
+        availableQuantity        <- map["availableQuantity"]
+        channels                 <- map["channels"]
+    }
+
+
+
+}

--- a/Source/Models/ProductVariantAvailability.swift
+++ b/Source/Models/ProductVariantAvailability.swift
@@ -4,7 +4,7 @@
 
 import ObjectMapper
 
-struct ProductVariantAvailability: Mappable {
+public struct ProductVariantAvailability: Mappable {
 
     // MARK: - Properties
 
@@ -13,11 +13,11 @@ struct ProductVariantAvailability: Mappable {
     var availableQuantity: Int?
     var channels: [String: ProductVariantAvailability]?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         isOnStock                <- map["isOnStock"]
         restockableInDays        <- map["restockableInDays"]
         availableQuantity        <- map["availableQuantity"]

--- a/Source/Models/Reference.swift
+++ b/Source/Models/Reference.swift
@@ -4,7 +4,7 @@
 
 import ObjectMapper
 
-struct Reference<T: Mappable>: Mappable {
+public struct Reference<T: Mappable>: Mappable {
 
     // MARK: - Properties
 
@@ -12,11 +12,11 @@ struct Reference<T: Mappable>: Mappable {
     var typeId: String?
     var obj: T?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         id              <- map["id"]
         typeId          <- map["typeId"]
         obj             <- map["obj"]
@@ -24,18 +24,18 @@ struct Reference<T: Mappable>: Mappable {
 
 }
 
-struct GenericReference: Mappable {
+public struct GenericReference: Mappable {
     
     // MARK: - Properties
     
     var id: String?
     var typeId: String?
     
-    init?(map: Map) {}
+    public init?(map: Map) {}
     
     // MARK: - Mappable
     
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         id              <- map["id"]
         typeId          <- map["typeId"]
     }

--- a/Source/Models/Reference.swift
+++ b/Source/Models/Reference.swift
@@ -1,0 +1,43 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+
+struct Reference<T: Mappable>: Mappable {
+
+    // MARK: - Properties
+
+    var id: String?
+    var typeId: String?
+    var obj: T?
+
+    init?(map: Map) {}
+
+    // MARK: - Mappable
+
+    mutating func mapping(map: Map) {
+        id              <- map["id"]
+        typeId          <- map["typeId"]
+        obj             <- map["obj"]
+    }
+
+}
+
+struct GenericReference: Mappable {
+    
+    // MARK: - Properties
+    
+    var id: String?
+    var typeId: String?
+    
+    init?(map: Map) {}
+    
+    // MARK: - Mappable
+    
+    mutating func mapping(map: Map) {
+        id              <- map["id"]
+        typeId          <- map["typeId"]
+    }
+    
+}

--- a/Source/Models/ReviewRatingStatistics.swift
+++ b/Source/Models/ReviewRatingStatistics.swift
@@ -4,7 +4,7 @@
 
 import ObjectMapper
 
-struct ReviewRatingStatistics: Mappable {
+public struct ReviewRatingStatistics: Mappable {
 
     // MARK: - Properties
 
@@ -14,11 +14,11 @@ struct ReviewRatingStatistics: Mappable {
     var count: UInt?
     var ratingsDistribution: [String: Any]?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         averageRating        <- map["averageRating"]
         highestRating        <- map["highestRating"]
         lowestRating         <- map["lowestRating"]

--- a/Source/Models/ReviewRatingStatistics.swift
+++ b/Source/Models/ReviewRatingStatistics.swift
@@ -1,0 +1,28 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+
+struct ReviewRatingStatistics: Mappable {
+
+    // MARK: - Properties
+
+    var averageRating: Double?
+    var highestRating: Double?
+    var lowestRating: Double?
+    var count: UInt?
+    var ratingsDistribution: [String: Any]?
+
+    init?(map: Map) {}
+
+    // MARK: - Mappable
+
+    mutating func mapping(map: Map) {
+        averageRating        <- map["averageRating"]
+        highestRating        <- map["highestRating"]
+        lowestRating         <- map["lowestRating"]
+        count                <- map["count"]
+        ratingsDistribution  <- map["ratingsDistribution"]
+    }
+}

--- a/Source/Models/ShippingInfo.swift
+++ b/Source/Models/ShippingInfo.swift
@@ -1,0 +1,36 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+struct ShippingInfo: Mappable {
+    
+    // MARK: - Properties
+    
+    var shippingMethodName: String?
+    var price: Money?
+    var shippingRate: ShippingRate?
+    var taxedPrice: TaxedItemPrice?
+    var taxRate: TaxRate?
+    var taxCategory: Reference<TaxCategory>?
+    var shippingMethod: Reference<ShippingMethod>?
+    var deliveries: [Delivery]?
+    var discountedPrice: DiscountedLineItemPrice?
+
+    init?(map: Map) {}
+    
+    // MARK: - Mappable
+    
+    mutating func mapping(map: Map) {
+        shippingMethodName         <- map["shippingMethodName"]
+        price                      <- map["price"]
+        shippingRate               <- map["shippingRate"]
+        taxedPrice                 <- map["taxedPrice"]
+        taxRate                    <- map["taxRate"]
+        taxCategory                <- map["taxCategory"]
+        shippingMethod             <- map["shippingMethod"]
+        deliveries                 <- map["deliveries"]
+        discountedPrice            <- map["discountedPrice"]
+    }
+    
+}

--- a/Source/Models/ShippingInfo.swift
+++ b/Source/Models/ShippingInfo.swift
@@ -3,7 +3,7 @@
 //
 
 import ObjectMapper
-struct ShippingInfo: Mappable {
+public struct ShippingInfo: Mappable {
     
     // MARK: - Properties
     
@@ -17,11 +17,11 @@ struct ShippingInfo: Mappable {
     var deliveries: [Delivery]?
     var discountedPrice: DiscountedLineItemPrice?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
     
     // MARK: - Mappable
     
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         shippingMethodName         <- map["shippingMethodName"]
         price                      <- map["price"]
         shippingRate               <- map["shippingRate"]

--- a/Source/Models/ShippingMethod.swift
+++ b/Source/Models/ShippingMethod.swift
@@ -4,7 +4,7 @@
 
 import ObjectMapper
 
-struct ShippingMethod: Mappable {
+public struct ShippingMethod: Mappable {
 
     // MARK: - Properties
 
@@ -18,11 +18,11 @@ struct ShippingMethod: Mappable {
     var zoneRates: [ZoneRate]?
     var isDefault: Bool?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         id               <- map["id"]
         version          <- map["version"]
         createdAt        <- (map["createdAt"], ISO8601DateTransform())

--- a/Source/Models/ShippingMethod.swift
+++ b/Source/Models/ShippingMethod.swift
@@ -1,0 +1,37 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+
+struct ShippingMethod: Mappable {
+
+    // MARK: - Properties
+
+    var id: String?
+    var version: UInt?
+    var createdAt: Date?
+    var lastModifiedAt: Date?
+    var name: String?
+    var description: String?
+    var taxCategory: Reference<TaxCategory>?
+    var zoneRates: [ZoneRate]?
+    var isDefault: Bool?
+
+    init?(map: Map) {}
+
+    // MARK: - Mappable
+
+    mutating func mapping(map: Map) {
+        id               <- map["id"]
+        version          <- map["version"]
+        createdAt        <- (map["createdAt"], ISO8601DateTransform())
+        lastModifiedAt   <- (map["lastModifiedAt"], ISO8601DateTransform())
+        name             <- map["name"]
+        description      <- map["description"]
+        taxCategory      <- map["taxCategory"]
+        zoneRates        <- map["zoneRates"]
+        isDefault        <- map["isDefault"]
+    }
+
+}

--- a/Source/Models/ShippingRate.swift
+++ b/Source/Models/ShippingRate.swift
@@ -4,18 +4,18 @@
 
 import ObjectMapper
 
-struct ShippingRate: Mappable {
+public struct ShippingRate: Mappable {
 
     // MARK: - Properties
 
     var price: Money?
     var freeAbove: Money?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         price             <- map["price"]
         freeAbove         <- map["freeAbove"]
     }

--- a/Source/Models/ShippingRate.swift
+++ b/Source/Models/ShippingRate.swift
@@ -4,19 +4,20 @@
 
 import ObjectMapper
 
-struct Money: Mappable {
+struct ShippingRate: Mappable {
 
     // MARK: - Properties
 
-    var currencyCode: String?
-    var centAmount: Int?
+    var price: Money?
+    var freeAbove: Money?
 
     init?(map: Map) {}
 
     // MARK: - Mappable
 
     mutating func mapping(map: Map) {
-        currencyCode       <- map["currencyCode"]
-        centAmount         <- map["centAmount"]
+        price             <- map["price"]
+        freeAbove         <- map["freeAbove"]
     }
+
 }

--- a/Source/Models/State.swift
+++ b/Source/Models/State.swift
@@ -4,7 +4,7 @@
 
 import ObjectMapper
 
-struct State: Mappable {
+public struct State: Mappable {
 
     // MARK: - Properties
 
@@ -21,11 +21,11 @@ struct State: Mappable {
     var roles: [StateRole]?
     var transitions: [Reference<State>]?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         id                <- map["id"]
         version           <- map["version"]
         createdAt         <- (map["createdAt"], ISO8601DateTransform())

--- a/Source/Models/State.swift
+++ b/Source/Models/State.swift
@@ -1,0 +1,43 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+
+struct State: Mappable {
+
+    // MARK: - Properties
+
+    var id: String?
+    var version: UInt?
+    var createdAt: Date?
+    var lastModifiedAt: Date?
+    var key: String?
+    var type: StateType?
+    var name: LocalizedString?
+    var description: LocalizedString?
+    var initial: Bool?
+    var builtIn: Bool?
+    var roles: [StateRole]?
+    var transitions: [Reference<State>]?
+
+    init?(map: Map) {}
+
+    // MARK: - Mappable
+
+    mutating func mapping(map: Map) {
+        id                <- map["id"]
+        version           <- map["version"]
+        createdAt         <- (map["createdAt"], ISO8601DateTransform())
+        lastModifiedAt    <- (map["lastModifiedAt"], ISO8601DateTransform())
+        key               <- map["key"]
+        type              <- map["type"]
+        name              <- map["name"]
+        description       <- map["description"]
+        initial           <- map["initial"]
+        builtIn           <- map["builtIn"]
+        roles             <- map["roles"]
+        transitions       <- map["transitions"]
+    }
+
+}

--- a/Source/Models/StateRole.swift
+++ b/Source/Models/StateRole.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-enum StateRole: String {
+public enum StateRole: String {
 
     case reviewIncludedInStatistics = "ReviewIncludedInStatistics"
 

--- a/Source/Models/StateRole.swift
+++ b/Source/Models/StateRole.swift
@@ -1,0 +1,11 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import Foundation
+
+enum StateRole: String {
+
+    case reviewIncludedInStatistics = "ReviewIncludedInStatistics"
+
+}

--- a/Source/Models/StateType.swift
+++ b/Source/Models/StateType.swift
@@ -1,0 +1,15 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import Foundation
+
+enum StateType: String {
+
+    case orderState = "OrderState"
+    case lineItemState = "LineItemState"
+    case productState =  "ProductState"
+    case reviewState = "ReviewState"
+    case paymentState = "PaymentState"
+
+}

--- a/Source/Models/StateType.swift
+++ b/Source/Models/StateType.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-enum StateType: String {
+public enum StateType: String {
 
     case orderState = "OrderState"
     case lineItemState = "LineItemState"

--- a/Source/Models/SubRate.swift
+++ b/Source/Models/SubRate.swift
@@ -4,19 +4,20 @@
 
 import ObjectMapper
 
-struct Money: Mappable {
+struct SubRate: Mappable {
 
     // MARK: - Properties
 
-    var currencyCode: String?
-    var centAmount: Int?
+    var name: String?
+    var amount: Double?
 
     init?(map: Map) {}
 
     // MARK: - Mappable
 
     mutating func mapping(map: Map) {
-        currencyCode       <- map["currencyCode"]
-        centAmount         <- map["centAmount"]
+        name       <- map["name"]
+        amount     <- map["amount"]
     }
+
 }

--- a/Source/Models/SubRate.swift
+++ b/Source/Models/SubRate.swift
@@ -4,18 +4,18 @@
 
 import ObjectMapper
 
-struct SubRate: Mappable {
+public struct SubRate: Mappable {
 
     // MARK: - Properties
 
     var name: String?
     var amount: Double?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         name       <- map["name"]
         amount     <- map["amount"]
     }

--- a/Source/Models/TaxCategory.swift
+++ b/Source/Models/TaxCategory.swift
@@ -1,0 +1,33 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+
+struct TaxCategory: Mappable {
+
+    // MARK: - Properties
+
+    var id: String?
+    var version: UInt?
+    var createdAt: Date?
+    var lastModifiedAt: Date?
+    var name: String?
+    var description: String?
+    var rates: [TaxRate]?
+
+    init?(map: Map) {}
+
+    // MARK: - Mappable
+
+    mutating func mapping(map: Map) {
+        id               <- map["id"]
+        version          <- map["version"]
+        createdAt        <- (map["createdAt"], ISO8601DateTransform())
+        lastModifiedAt   <- (map["lastModifiedAt"], ISO8601DateTransform())
+        name             <- map["name"]
+        description      <- map["description"]
+        rates            <- map["rates"]
+    }
+
+}

--- a/Source/Models/TaxCategory.swift
+++ b/Source/Models/TaxCategory.swift
@@ -4,7 +4,7 @@
 
 import ObjectMapper
 
-struct TaxCategory: Mappable {
+public struct TaxCategory: Mappable {
 
     // MARK: - Properties
 
@@ -16,11 +16,11 @@ struct TaxCategory: Mappable {
     var description: String?
     var rates: [TaxRate]?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         id               <- map["id"]
         version          <- map["version"]
         createdAt        <- (map["createdAt"], ISO8601DateTransform())

--- a/Source/Models/TaxMode.swift
+++ b/Source/Models/TaxMode.swift
@@ -1,0 +1,13 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import Foundation
+
+enum TaxMode: String {
+    
+    case platform = "Platform"
+    case external = "External"
+    case disabled = "Disabled"
+    
+}

--- a/Source/Models/TaxMode.swift
+++ b/Source/Models/TaxMode.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-enum TaxMode: String {
+public enum TaxMode: String {
     
     case platform = "Platform"
     case external = "External"

--- a/Source/Models/TaxRate.swift
+++ b/Source/Models/TaxRate.swift
@@ -4,7 +4,7 @@
 
 import ObjectMapper
 
-struct TaxRate: Mappable {
+public struct TaxRate: Mappable {
 
     // MARK: - Properties
 
@@ -15,11 +15,11 @@ struct TaxRate: Mappable {
     var state: String?
     var subRates: [SubRate]?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         id                <- map["id"]
         name              <- map["name"]
         includedInPrice   <- map["includedInPrice"]

--- a/Source/Models/TaxRate.swift
+++ b/Source/Models/TaxRate.swift
@@ -1,0 +1,31 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+
+struct TaxRate: Mappable {
+
+    // MARK: - Properties
+
+    var id: String?
+    var name: String?
+    var includedInPrice: Bool?
+    var country: String?
+    var state: String?
+    var subRates: [SubRate]?
+
+    init?(map: Map) {}
+
+    // MARK: - Mappable
+
+    mutating func mapping(map: Map) {
+        id                <- map["id"]
+        name              <- map["name"]
+        includedInPrice   <- map["includedInPrice"]
+        country           <- map["country"]
+        state             <- map["state"]
+        subRates          <- map["subRates"]
+    }
+
+}

--- a/Source/Models/TaxedItemPrice.swift
+++ b/Source/Models/TaxedItemPrice.swift
@@ -4,19 +4,20 @@
 
 import ObjectMapper
 
-struct Money: Mappable {
+struct TaxedItemPrice: Mappable {
 
     // MARK: - Properties
 
-    var currencyCode: String?
-    var centAmount: Int?
+    var totalNet: Money?
+    var totalGross: Money?
 
     init?(map: Map) {}
 
     // MARK: - Mappable
 
     mutating func mapping(map: Map) {
-        currencyCode       <- map["currencyCode"]
-        centAmount         <- map["centAmount"]
+        totalNet                <- map["totalNet"]
+        totalGross              <- map["totalGross"]
     }
+
 }

--- a/Source/Models/TaxedItemPrice.swift
+++ b/Source/Models/TaxedItemPrice.swift
@@ -4,18 +4,18 @@
 
 import ObjectMapper
 
-struct TaxedItemPrice: Mappable {
+public struct TaxedItemPrice: Mappable {
 
     // MARK: - Properties
 
     var totalNet: Money?
     var totalGross: Money?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         totalNet                <- map["totalNet"]
         totalGross              <- map["totalGross"]
     }

--- a/Source/Models/TaxedPrice.swift
+++ b/Source/Models/TaxedPrice.swift
@@ -1,0 +1,23 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+
+struct TaxedPrice: Mappable {
+
+    // MARK: - Properties
+
+    var totalNet: Money?
+    var totalGross: Money?
+
+    init?(map: Map) {}
+
+    // MARK: - Mappable
+
+    mutating func mapping(map: Map) {
+        totalNet         <- map["totalNet"]
+        totalGross       <- map["totalGross"]
+    }
+
+}

--- a/Source/Models/TaxedPrice.swift
+++ b/Source/Models/TaxedPrice.swift
@@ -4,18 +4,18 @@
 
 import ObjectMapper
 
-struct TaxedPrice: Mappable {
+public struct TaxedPrice: Mappable {
 
     // MARK: - Properties
 
     var totalNet: Money?
     var totalGross: Money?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         totalNet         <- map["totalNet"]
         totalGross       <- map["totalGross"]
     }

--- a/Source/Models/TrackingData.swift
+++ b/Source/Models/TrackingData.swift
@@ -1,0 +1,29 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+
+struct TrackingData: Mappable {
+
+    // MARK: - Properties
+
+    var trackingId: String?
+    var carrier: String?
+    var provider: String?
+    var providerTransaction: String?
+    var isReturn: Bool?
+
+    init?(map: Map) {}
+
+    // MARK: - Mappable
+
+    mutating func mapping(map: Map) {
+        trackingId           <- map["trackingId"]
+        carrier              <- map["carrier"]
+        provider             <- map["provider"]
+        providerTransaction  <- map["providerTransaction"]
+        isReturn             <- map["isReturn"]
+    }
+
+}

--- a/Source/Models/TrackingData.swift
+++ b/Source/Models/TrackingData.swift
@@ -4,7 +4,7 @@
 
 import ObjectMapper
 
-struct TrackingData: Mappable {
+public struct TrackingData: Mappable {
 
     // MARK: - Properties
 
@@ -14,11 +14,11 @@ struct TrackingData: Mappable {
     var providerTransaction: String?
     var isReturn: Bool?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         trackingId           <- map["trackingId"]
         carrier              <- map["carrier"]
         provider             <- map["provider"]

--- a/Source/Models/Transaction.swift
+++ b/Source/Models/Transaction.swift
@@ -4,7 +4,7 @@
 
 import ObjectMapper
 
-struct Transaction: Mappable {
+public struct Transaction: Mappable {
 
     // MARK: - Properties
 
@@ -15,11 +15,11 @@ struct Transaction: Mappable {
     var interactionId: String?
     var state: TransactionState?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         id                    <- map["id"]
         timestamp             <- map["timestamp"]
         type                  <- map["type"]

--- a/Source/Models/Transaction.swift
+++ b/Source/Models/Transaction.swift
@@ -1,0 +1,31 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+
+struct Transaction: Mappable {
+
+    // MARK: - Properties
+
+    var id: String?
+    var timestamp: Date?
+    var type: TransactionType?
+    var amount: Money?
+    var interactionId: String?
+    var state: TransactionState?
+
+    init?(map: Map) {}
+
+    // MARK: - Mappable
+
+    mutating func mapping(map: Map) {
+        id                    <- map["id"]
+        timestamp             <- map["timestamp"]
+        type                  <- map["type"]
+        amount                <- map["amount"]
+        interactionId         <- map["interactionId"]
+        state                 <- map["state"]
+    }
+
+}

--- a/Source/Models/TransactionState.swift
+++ b/Source/Models/TransactionState.swift
@@ -1,0 +1,13 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import Foundation
+
+enum TransactionState: String {
+
+    case pending = "Pending"
+    case success = "Success"
+    case failure = "Failure"
+
+}

--- a/Source/Models/TransactionState.swift
+++ b/Source/Models/TransactionState.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-enum TransactionState: String {
+public enum TransactionState: String {
 
     case pending = "Pending"
     case success = "Success"

--- a/Source/Models/TransactionType.swift
+++ b/Source/Models/TransactionType.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-enum TransactionType: String {
+public enum TransactionType: String {
 
     case authorization = "Authorization"
     case cancelAuthorization = "CancelAuthorization"

--- a/Source/Models/TransactionType.swift
+++ b/Source/Models/TransactionType.swift
@@ -1,0 +1,15 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import Foundation
+
+enum TransactionType: String {
+
+    case authorization = "Authorization"
+    case cancelAuthorization = "CancelAuthorization"
+    case charge =  "Charge"
+    case refund = "Refund"
+    case chargeback = "Chargeback"
+
+}

--- a/Source/Models/Zone.swift
+++ b/Source/Models/Zone.swift
@@ -4,7 +4,7 @@
 
 import ObjectMapper
 
-struct Zone: Mappable {
+public struct Zone: Mappable {
 
     // MARK: - Properties
 
@@ -16,11 +16,11 @@ struct Zone: Mappable {
     var description: String?
     var locations: [Location]?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         id               <- map["id"]
         version          <- map["version"]
         createdAt        <- (map["createdAt"], ISO8601DateTransform())

--- a/Source/Models/Zone.swift
+++ b/Source/Models/Zone.swift
@@ -1,0 +1,33 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import ObjectMapper
+
+struct Zone: Mappable {
+
+    // MARK: - Properties
+
+    var id: String?
+    var version: UInt?
+    var createdAt: Date?
+    var lastModifiedAt: Date?
+    var name: String?
+    var description: String?
+    var locations: [Location]?
+
+    init?(map: Map) {}
+
+    // MARK: - Mappable
+
+    mutating func mapping(map: Map) {
+        id               <- map["id"]
+        version          <- map["version"]
+        createdAt        <- (map["createdAt"], ISO8601DateTransform())
+        lastModifiedAt   <- (map["lastModifiedAt"], ISO8601DateTransform())
+        name             <- map["name"]
+        description      <- map["description"]
+        locations        <- map["locations"]
+    }
+
+}

--- a/Source/Models/ZoneRate.swift
+++ b/Source/Models/ZoneRate.swift
@@ -4,19 +4,20 @@
 
 import ObjectMapper
 
-struct Money: Mappable {
+struct ZoneRate: Mappable {
 
     // MARK: - Properties
 
-    var currencyCode: String?
-    var centAmount: Int?
+    var zone: Reference<Zone>?
+    var shippingRates: [ShippingRate]?
 
     init?(map: Map) {}
 
     // MARK: - Mappable
 
     mutating func mapping(map: Map) {
-        currencyCode       <- map["currencyCode"]
-        centAmount         <- map["centAmount"]
+        zone              <- map["zone"]
+        shippingRates     <- map["shippingRates"]
     }
+
 }

--- a/Source/Models/ZoneRate.swift
+++ b/Source/Models/ZoneRate.swift
@@ -4,18 +4,18 @@
 
 import ObjectMapper
 
-struct ZoneRate: Mappable {
+public struct ZoneRate: Mappable {
 
     // MARK: - Properties
 
     var zone: Reference<Zone>?
     var shippingRates: [ShippingRate]?
 
-    init?(map: Map) {}
+    public init?(map: Map) {}
 
     // MARK: - Mappable
 
-    mutating func mapping(map: Map) {
+    mutating public func mapping(map: Map) {
         zone              <- map["zone"]
         shippingRates     <- map["shippingRates"]
     }

--- a/Source/Result.swift
+++ b/Source/Result.swift
@@ -2,7 +2,7 @@
 // Copyright (c) 2016 Commercetools. All rights reserved.
 //
 
-import Foundation
+import ObjectMapper
 
 /**
     Used to represent whether a result from an endpoint operation was successful or not.
@@ -12,8 +12,8 @@ import Foundation
     - Failure: The result from the Commercetools endpoint encountered an error resulting in a failure. Provided status
                code and an array of errors should be used to examine the origin of the problem.
 */
-public enum Result<Response> {
-    case success(Response)
+public enum Result<Response: Mappable> {
+    case success([String: Any])
     case failure(Int?, [Error])
 
     /// Returns `true` if the result is a success, `false` otherwise.
@@ -31,11 +31,21 @@ public enum Result<Response> {
         return !isSuccess
     }
 
-    /// Returns the associated response if the result is a success, `nil` otherwise.
-    public var response: Response? {
+    /// Returns the associated JSON response in dictionary format, if the result is a success, `nil` otherwise.
+    public var json: [String: Any]? {
         switch self {
         case .success(let value):
             return value
+        case .failure:
+            return nil
+        }
+    }
+
+    /// Returns the associated response, with in the  if the result is a success, `nil` otherwise.
+    public var model: Response? {
+        switch self {
+        case .success(let value):
+            return Mapper<Response>().map(JSONObject: value)
         case .failure:
             return nil
         }

--- a/Tests/AuthManagerTests.swift
+++ b/Tests/AuthManagerTests.swift
@@ -168,8 +168,8 @@ class AuthManagerTests: XCTestCase {
 
         authManager.obtainAnonymousToken(usingSession: true, anonymousId: anonymousId, completionHandler: { error in
             if error == nil && authManager.state == .anonymousToken {
-                Cart.create(["currency": "EUR"], dictionaryResult: { result in
-                    if let response = result.response, let cartAnonymousId = response["anonymousId"] as? String,
+                Cart.create(["currency": "EUR"], result: { result in
+                    if let response = result.json, let cartAnonymousId = response["anonymousId"] as? String,
                             result.isSuccess && cartAnonymousId == anonymousId {
                         anonymousIdExpectation.fulfill()
                     }

--- a/Tests/AuthManagerTests.swift
+++ b/Tests/AuthManagerTests.swift
@@ -168,7 +168,7 @@ class AuthManagerTests: XCTestCase {
 
         authManager.obtainAnonymousToken(usingSession: true, anonymousId: anonymousId, completionHandler: { error in
             if error == nil && authManager.state == .anonymousToken {
-                Cart.create(["currency": "EUR"], result: { result in
+                Cart.create(["currency": "EUR"], dictionaryResult: { result in
                     if let response = result.response, let cartAnonymousId = response["anonymousId"] as? String,
                             result.isSuccess && cartAnonymousId == anonymousId {
                         anonymousIdExpectation.fulfill()

--- a/Tests/Core/ByIdEndpointTests.swift
+++ b/Tests/Core/ByIdEndpointTests.swift
@@ -37,10 +37,10 @@ class ByIdEndpointTests: XCTestCase {
         
         AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
         
-        TestCart.create(["currency": "EUR"], dictionaryResult: { result in
-            if let response = result.response, let id = response["id"] as? String, result.isSuccess {
-                TestCart.byId(id, dictionaryResult: { result in
-                    if let response = result.response, let cartState = response["cartState"] as? String,
+        TestCart.create(["currency": "EUR"], result: { result in
+            if let response = result.json, let id = response["id"] as? String, result.isSuccess {
+                TestCart.byId(id, result: { result in
+                    if let response = result.json, let cartState = response["cartState"] as? String,
                             let version = response["version"] as? Int, let obtainedId = response["id"] as? String, result.isSuccess && cartState == "Active" && version == 1 && obtainedId == id {
                         byIdExpectation.fulfill()
                     }
@@ -60,7 +60,7 @@ class ByIdEndpointTests: XCTestCase {
 
         AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
 
-        TestCart.byId("cddddddd-ffff-4b44-b5b0-004e7d4bc2dd", dictionaryResult: { result in
+        TestCart.byId("cddddddd-ffff-4b44-b5b0-004e7d4bc2dd", result: { result in
             if let error = result.errors?.first as? CTError, result.statusCode == 404, case .resourceNotFoundError(let reason) = error,
                     reason.message == "The Resource with ID 'cddddddd-ffff-4b44-b5b0-004e7d4bc2dd' was not found." {
                 byIdExpectation.fulfill()
@@ -74,11 +74,11 @@ class ByIdEndpointTests: XCTestCase {
 
         let byIdExpectation = expectation(description: "byId expectation")
 
-        TestProductProjections.query(limit: 1, dictionaryResult: { result in
-            if let response = result.response, let results = response["results"] as? [[String: AnyObject]],
+        TestProductProjections.query(limit: 1, result: { result in
+            if let response = result.json, let results = response["results"] as? [[String: AnyObject]],
                     let id = results.first?["id"] as? String, result.isSuccess {
-                TestProductProjections.byId(id, expansion: ["productType"], dictionaryResult: { result in
-                    if let response = result.response, let productType = response["productType"] as? [String: AnyObject],
+                TestProductProjections.byId(id, expansion: ["productType"], result: { result in
+                    if let response = result.json, let productType = response["productType"] as? [String: AnyObject],
                     let productTypeObject = productType["obj"] as? [String: AnyObject], result.isSuccess && productTypeObject.count > 0 {
                         byIdExpectation.fulfill()
                     }

--- a/Tests/Core/ByIdEndpointTests.swift
+++ b/Tests/Core/ByIdEndpointTests.swift
@@ -13,7 +13,7 @@ class ByIdEndpointTests: XCTestCase {
     }
 
     private class TestProductProjections: ByIdEndpoint, QueryEndpoint {
-        public typealias ResponseType = ProductProjection
+        public typealias ResponseType = NoMapping
         static let path = "product-projections"
     }
     

--- a/Tests/Core/ByIdEndpointTests.swift
+++ b/Tests/Core/ByIdEndpointTests.swift
@@ -39,7 +39,7 @@ class ByIdEndpointTests: XCTestCase {
         
         TestCart.create(["currency": "EUR"], dictionaryResult: { result in
             if let response = result.response, let id = response["id"] as? String, result.isSuccess {
-                TestCart.byId(id, result: { result in
+                TestCart.byId(id, dictionaryResult: { result in
                     if let response = result.response, let cartState = response["cartState"] as? String,
                             let version = response["version"] as? Int, let obtainedId = response["id"] as? String, result.isSuccess && cartState == "Active" && version == 1 && obtainedId == id {
                         byIdExpectation.fulfill()
@@ -60,7 +60,7 @@ class ByIdEndpointTests: XCTestCase {
 
         AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
 
-        TestCart.byId("cddddddd-ffff-4b44-b5b0-004e7d4bc2dd", result: { result in
+        TestCart.byId("cddddddd-ffff-4b44-b5b0-004e7d4bc2dd", dictionaryResult: { result in
             if let error = result.errors?.first as? CTError, result.statusCode == 404, case .resourceNotFoundError(let reason) = error,
                     reason.message == "The Resource with ID 'cddddddd-ffff-4b44-b5b0-004e7d4bc2dd' was not found." {
                 byIdExpectation.fulfill()
@@ -74,10 +74,10 @@ class ByIdEndpointTests: XCTestCase {
 
         let byIdExpectation = expectation(description: "byId expectation")
 
-        TestProductProjections.query(limit: 1, result: { result in
+        TestProductProjections.query(limit: 1, dictionaryResult: { result in
             if let response = result.response, let results = response["results"] as? [[String: AnyObject]],
                     let id = results.first?["id"] as? String, result.isSuccess {
-                TestProductProjections.byId(id, expansion: ["productType"], result: { result in
+                TestProductProjections.byId(id, expansion: ["productType"], dictionaryResult: { result in
                     if let response = result.response, let productType = response["productType"] as? [String: AnyObject],
                     let productTypeObject = productType["obj"] as? [String: AnyObject], result.isSuccess && productTypeObject.count > 0 {
                         byIdExpectation.fulfill()

--- a/Tests/Core/ByIdEndpointTests.swift
+++ b/Tests/Core/ByIdEndpointTests.swift
@@ -8,10 +8,12 @@ import XCTest
 class ByIdEndpointTests: XCTestCase {
     
     private class TestCart: ByIdEndpoint, CreateEndpoint {
+        public typealias ResponseType = [String: Any]
         static let path = "me/carts"
     }
 
     private class TestProductProjections: ByIdEndpoint, QueryEndpoint {
+        public typealias ResponseType = [String: Any]
         static let path = "product-projections"
     }
     

--- a/Tests/Core/ByIdEndpointTests.swift
+++ b/Tests/Core/ByIdEndpointTests.swift
@@ -8,12 +8,12 @@ import XCTest
 class ByIdEndpointTests: XCTestCase {
     
     private class TestCart: ByIdEndpoint, CreateEndpoint {
-        public typealias ResponseType = [String: Any]
+        public typealias ResponseType = Cart
         static let path = "me/carts"
     }
 
     private class TestProductProjections: ByIdEndpoint, QueryEndpoint {
-        public typealias ResponseType = [String: Any]
+        public typealias ResponseType = ProductProjection
         static let path = "product-projections"
     }
     
@@ -37,7 +37,7 @@ class ByIdEndpointTests: XCTestCase {
         
         AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
         
-        TestCart.create(["currency": "EUR"], result: { result in
+        TestCart.create(["currency": "EUR"], dictionaryResult: { result in
             if let response = result.response, let id = response["id"] as? String, result.isSuccess {
                 TestCart.byId(id, result: { result in
                     if let response = result.response, let cartState = response["cartState"] as? String,

--- a/Tests/Core/ByKeyEndpointTests.swift
+++ b/Tests/Core/ByKeyEndpointTests.swift
@@ -8,7 +8,7 @@ import XCTest
 class ByKeyEndpointTests: XCTestCase {
 
     private class TestProductType: ByKeyEndpoint {
-        public typealias ResponseType = [String: Any]
+        public typealias ResponseType = ProductType
         static let path = "product-types"
     }
 

--- a/Tests/Core/ByKeyEndpointTests.swift
+++ b/Tests/Core/ByKeyEndpointTests.swift
@@ -27,7 +27,7 @@ class ByKeyEndpointTests: XCTestCase {
 
         let byKeyExpectation = expectation(description: "byKey expectation")
 
-        TestProductType.byKey("main", result: { result in
+        TestProductType.byKey("main", dictionaryResult: { result in
             if let response = result.response, let description = response["description"] as? String,
                     result.isSuccess && description == "all products of max" {
                 byKeyExpectation.fulfill()
@@ -41,7 +41,7 @@ class ByKeyEndpointTests: XCTestCase {
 
         let byKeyExpectation = expectation(description: "byKey expectation")
 
-        TestProductType.byKey("second", result: { result in
+        TestProductType.byKey("second", dictionaryResult: { result in
             if let error = result.errors?.first as? CTError, result.statusCode == 404, case .resourceNotFoundError(let reason) = error,
                     reason.message == "The Resource with key 'second' was not found." {
                 byKeyExpectation.fulfill()

--- a/Tests/Core/ByKeyEndpointTests.swift
+++ b/Tests/Core/ByKeyEndpointTests.swift
@@ -27,8 +27,8 @@ class ByKeyEndpointTests: XCTestCase {
 
         let byKeyExpectation = expectation(description: "byKey expectation")
 
-        TestProductType.byKey("main", dictionaryResult: { result in
-            if let response = result.response, let description = response["description"] as? String,
+        TestProductType.byKey("main", result: { result in
+            if let response = result.json, let description = response["description"] as? String,
                     result.isSuccess && description == "all products of max" {
                 byKeyExpectation.fulfill()
             }
@@ -41,7 +41,7 @@ class ByKeyEndpointTests: XCTestCase {
 
         let byKeyExpectation = expectation(description: "byKey expectation")
 
-        TestProductType.byKey("second", dictionaryResult: { result in
+        TestProductType.byKey("second", result: { result in
             if let error = result.errors?.first as? CTError, result.statusCode == 404, case .resourceNotFoundError(let reason) = error,
                     reason.message == "The Resource with key 'second' was not found." {
                 byKeyExpectation.fulfill()

--- a/Tests/Core/ByKeyEndpointTests.swift
+++ b/Tests/Core/ByKeyEndpointTests.swift
@@ -8,6 +8,7 @@ import XCTest
 class ByKeyEndpointTests: XCTestCase {
 
     private class TestProductType: ByKeyEndpoint {
+        public typealias ResponseType = [String: Any]
         static let path = "product-types"
     }
 

--- a/Tests/Core/ByKeyEndpointTests.swift
+++ b/Tests/Core/ByKeyEndpointTests.swift
@@ -8,7 +8,7 @@ import XCTest
 class ByKeyEndpointTests: XCTestCase {
 
     private class TestProductType: ByKeyEndpoint {
-        public typealias ResponseType = ProductType
+        public typealias ResponseType = NoMapping
         static let path = "product-types"
     }
 

--- a/Tests/Core/CreateEndpointTests.swift
+++ b/Tests/Core/CreateEndpointTests.swift
@@ -8,6 +8,7 @@ import XCTest
 class CreateEndpointTests: XCTestCase {
 
     private class TestCart: CreateEndpoint {
+        public typealias ResponseType = [String: Any]
         static let path = "me/carts"
     }
     

--- a/Tests/Core/CreateEndpointTests.swift
+++ b/Tests/Core/CreateEndpointTests.swift
@@ -32,8 +32,8 @@ class CreateEndpointTests: XCTestCase {
 
         AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
 
-        TestCart.create(["currency": "EUR"], dictionaryResult: { result in
-            if let response = result.response, let cartState = response["cartState"] as? String, let version = response["version"] as? Int,
+        TestCart.create(["currency": "EUR"], result: { result in
+            if let response = result.json, let cartState = response["cartState"] as? String, let version = response["version"] as? Int,
                     result.isSuccess && cartState == "Active" && version == 1 {
                 createExpectation.fulfill()
             }
@@ -51,7 +51,7 @@ class CreateEndpointTests: XCTestCase {
 
         AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
 
-        TestCart.create(["currency": "BAD"], dictionaryResult: { result in
+        TestCart.create(["currency": "BAD"], result: { result in
             if let error = result.errors?.first as? CTError, result.statusCode == 400, case .invalidJsonInputError(let reason) = error,
                     reason.message == "Request body does not contain valid JSON." &&
                     reason.details == "currency: ISO 4217 code JSON String expected" {

--- a/Tests/Core/CreateEndpointTests.swift
+++ b/Tests/Core/CreateEndpointTests.swift
@@ -8,7 +8,7 @@ import XCTest
 class CreateEndpointTests: XCTestCase {
 
     private class TestCart: CreateEndpoint {
-        public typealias ResponseType = [String: Any]
+        public typealias ResponseType = Cart
         static let path = "me/carts"
     }
     
@@ -32,7 +32,7 @@ class CreateEndpointTests: XCTestCase {
 
         AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
 
-        TestCart.create(["currency": "EUR"], result: { result in
+        TestCart.create(["currency": "EUR"], dictionaryResult: { result in
             if let response = result.response, let cartState = response["cartState"] as? String, let version = response["version"] as? Int,
                     result.isSuccess && cartState == "Active" && version == 1 {
                 createExpectation.fulfill()
@@ -51,7 +51,7 @@ class CreateEndpointTests: XCTestCase {
 
         AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
 
-        TestCart.create(["currency": "BAD"], result: { result in
+        TestCart.create(["currency": "BAD"], dictionaryResult: { result in
             if let error = result.errors?.first as? CTError, result.statusCode == 400, case .invalidJsonInputError(let reason) = error,
                     reason.message == "Request body does not contain valid JSON." &&
                     reason.details == "currency: ISO 4217 code JSON String expected" {

--- a/Tests/Core/DeleteEndpointTests.swift
+++ b/Tests/Core/DeleteEndpointTests.swift
@@ -8,7 +8,7 @@ import XCTest
 class DeleteEndpointTests: XCTestCase {
 
     private class TestCart: DeleteEndpoint, CreateEndpoint {
-        public typealias ResponseType = [String: Any]
+        public typealias ResponseType = Cart
         static let path = "me/carts"
     }
 
@@ -32,7 +32,7 @@ class DeleteEndpointTests: XCTestCase {
 
         AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
 
-        TestCart.create(["currency": "EUR"], result: { result in
+        TestCart.create(["currency": "EUR"], dictionaryResult: { result in
             if let response = result.response, let id = response["id"] as? String, let version = response["version"] as? UInt, result.isSuccess {
                 TestCart.delete(id, version: version, result: { result in
                     if let response = result.response, let deletedId = response["id"] as? String, result.isSuccess
@@ -55,7 +55,7 @@ class DeleteEndpointTests: XCTestCase {
 
         AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
 
-        TestCart.create(["currency": "EUR"], result: { result in
+        TestCart.create(["currency": "EUR"], dictionaryResult: { result in
             if let response = result.response, let id = response["id"] as? String, let version = response["version"] as? UInt, result.isSuccess {
                 TestCart.delete(id, version: version + 1, result: { result in
                     if let error = result.errors?.first as? CTError, result.statusCode == 409, case .concurrentModificationError(let reason, let currentVersion) = error,

--- a/Tests/Core/DeleteEndpointTests.swift
+++ b/Tests/Core/DeleteEndpointTests.swift
@@ -8,6 +8,7 @@ import XCTest
 class DeleteEndpointTests: XCTestCase {
 
     private class TestCart: DeleteEndpoint, CreateEndpoint {
+        public typealias ResponseType = [String: Any]
         static let path = "me/carts"
     }
 

--- a/Tests/Core/DeleteEndpointTests.swift
+++ b/Tests/Core/DeleteEndpointTests.swift
@@ -32,10 +32,10 @@ class DeleteEndpointTests: XCTestCase {
 
         AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
 
-        TestCart.create(["currency": "EUR"], dictionaryResult: { result in
-            if let response = result.response, let id = response["id"] as? String, let version = response["version"] as? UInt, result.isSuccess {
-                TestCart.delete(id, version: version, dictionaryResult: { result in
-                    if let response = result.response, let deletedId = response["id"] as? String, result.isSuccess
+        TestCart.create(["currency": "EUR"], result: { result in
+            if let response = result.json, let id = response["id"] as? String, let version = response["version"] as? UInt, result.isSuccess {
+                TestCart.delete(id, version: version, result: { result in
+                    if let response = result.json, let deletedId = response["id"] as? String, result.isSuccess
                             && deletedId == id {
                         deleteExpectation.fulfill()
                     }
@@ -55,9 +55,9 @@ class DeleteEndpointTests: XCTestCase {
 
         AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
 
-        TestCart.create(["currency": "EUR"], dictionaryResult: { result in
-            if let response = result.response, let id = response["id"] as? String, let version = response["version"] as? UInt, result.isSuccess {
-                TestCart.delete(id, version: version + 1, dictionaryResult: { result in
+        TestCart.create(["currency": "EUR"], result: { result in
+            if let response = result.json, let id = response["id"] as? String, let version = response["version"] as? UInt, result.isSuccess {
+                TestCart.delete(id, version: version + 1, result: { result in
                     if let error = result.errors?.first as? CTError, result.statusCode == 409, case .concurrentModificationError(let reason, let currentVersion) = error,
                             reason.message == "Object \(id) has a different version than expected. Expected: 2 - Actual: 1." && version == currentVersion {
                         deleteExpectation.fulfill()
@@ -78,7 +78,7 @@ class DeleteEndpointTests: XCTestCase {
 
         AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
 
-        TestCart.delete("cddddddd-ffff-4b44-b5b0-004e7d4bc2dd", version: 1, dictionaryResult: { result in
+        TestCart.delete("cddddddd-ffff-4b44-b5b0-004e7d4bc2dd", version: 1, result: { result in
             if let error = result.errors?.first as? CTError, result.statusCode == 404, case .resourceNotFoundError(let reason) = error,
                     reason.message == "The Cart with ID 'cddddddd-ffff-4b44-b5b0-004e7d4bc2dd' was not found." {
                 deleteExpectation.fulfill()

--- a/Tests/Core/DeleteEndpointTests.swift
+++ b/Tests/Core/DeleteEndpointTests.swift
@@ -34,7 +34,7 @@ class DeleteEndpointTests: XCTestCase {
 
         TestCart.create(["currency": "EUR"], dictionaryResult: { result in
             if let response = result.response, let id = response["id"] as? String, let version = response["version"] as? UInt, result.isSuccess {
-                TestCart.delete(id, version: version, result: { result in
+                TestCart.delete(id, version: version, dictionaryResult: { result in
                     if let response = result.response, let deletedId = response["id"] as? String, result.isSuccess
                             && deletedId == id {
                         deleteExpectation.fulfill()
@@ -57,7 +57,7 @@ class DeleteEndpointTests: XCTestCase {
 
         TestCart.create(["currency": "EUR"], dictionaryResult: { result in
             if let response = result.response, let id = response["id"] as? String, let version = response["version"] as? UInt, result.isSuccess {
-                TestCart.delete(id, version: version + 1, result: { result in
+                TestCart.delete(id, version: version + 1, dictionaryResult: { result in
                     if let error = result.errors?.first as? CTError, result.statusCode == 409, case .concurrentModificationError(let reason, let currentVersion) = error,
                             reason.message == "Object \(id) has a different version than expected. Expected: 2 - Actual: 1." && version == currentVersion {
                         deleteExpectation.fulfill()
@@ -78,7 +78,7 @@ class DeleteEndpointTests: XCTestCase {
 
         AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
 
-        TestCart.delete("cddddddd-ffff-4b44-b5b0-004e7d4bc2dd", version: 1, result: { result in
+        TestCart.delete("cddddddd-ffff-4b44-b5b0-004e7d4bc2dd", version: 1, dictionaryResult: { result in
             if let error = result.errors?.first as? CTError, result.statusCode == 404, case .resourceNotFoundError(let reason) = error,
                     reason.message == "The Cart with ID 'cddddddd-ffff-4b44-b5b0-004e7d4bc2dd' was not found." {
                 deleteExpectation.fulfill()

--- a/Tests/Core/QueryEndpointTests.swift
+++ b/Tests/Core/QueryEndpointTests.swift
@@ -8,7 +8,7 @@ import XCTest
 class QueryEndpointTests: XCTestCase {
 
     private class TestProductProjections: QueryEndpoint {
-        public typealias ResponseType = ProductProjection
+        public typealias ResponseType = NoMapping
         static let path = "product-projections"
     }
     

--- a/Tests/Core/QueryEndpointTests.swift
+++ b/Tests/Core/QueryEndpointTests.swift
@@ -29,7 +29,7 @@ class QueryEndpointTests: XCTestCase {
 
         let predicate = "slug(en=\"michael-kors-bag-30T3GTVT7L-lightbrown\")"
 
-        TestProductProjections.query(predicates: [predicate], result: { result in
+        TestProductProjections.query(predicates: [predicate], dictionaryResult: { result in
             if let response = result.response, let count = response["count"] as? Int,
                     let results = response["results"] as? [[String: AnyObject]],
                     let slug = results.first?["slug"] as? [String: String],
@@ -46,7 +46,7 @@ class QueryEndpointTests: XCTestCase {
 
         let queryExpectation = expectation(description: "query expectation")
 
-        TestProductProjections.query(sort: ["name.en asc"], limit: 8, result: { result in
+        TestProductProjections.query(sort: ["name.en asc"], limit: 8, dictionaryResult: { result in
             if let response = result.response, let count = response["count"] as? Int,
                     let results = response["results"] as? [[String: AnyObject]],
                     let name = results.first?["name"] as? [String: String], let enName = name["en"],
@@ -62,7 +62,7 @@ class QueryEndpointTests: XCTestCase {
 
         let queryExpectation = expectation(description: "query expectation")
 
-        TestProductProjections.query(sort: ["name.en asc"], limit: 2, offset: 1, result: { result in
+        TestProductProjections.query(sort: ["name.en asc"], limit: 2, offset: 1, dictionaryResult: { result in
             if let response = result.response, let count = response["count"] as? Int,
                     let results = response["results"] as? [[String: AnyObject]],
                     let name = results.first?["name"] as? [String: String], let enName = name["en"],
@@ -78,7 +78,7 @@ class QueryEndpointTests: XCTestCase {
 
         let queryExpectation = expectation(description: "query expectation")
 
-        TestProductProjections.query(sort: ["name.en asc", "slug.en asc"], limit: 1, result: { result in
+        TestProductProjections.query(sort: ["name.en asc", "slug.en asc"], limit: 1, dictionaryResult: { result in
             if let response = result.response, let count = response["count"] as? Int,
                     let results = response["results"] as? [[String: AnyObject]],
                     let name = results.first?["name"] as? [String: String], let enName = name["en"],
@@ -96,7 +96,7 @@ class QueryEndpointTests: XCTestCase {
 
         let predicate = "name(en=\"Bag “Jet Set Travel” Michael Kors light brown\")"
 
-        TestProductProjections.query(predicates: [predicate], expansion: ["productType"], result: { result in
+        TestProductProjections.query(predicates: [predicate], expansion: ["productType"], dictionaryResult: { result in
             if let response = result.response, let _ = response["count"] as? Int,
                     let results = response["results"] as? [[String: AnyObject]],
                     let productType = results.first?["productType"] as? [String: AnyObject],

--- a/Tests/Core/QueryEndpointTests.swift
+++ b/Tests/Core/QueryEndpointTests.swift
@@ -8,6 +8,7 @@ import XCTest
 class QueryEndpointTests: XCTestCase {
 
     private class TestProductProjections: QueryEndpoint {
+        public typealias ResponseType = [String: Any]
         static let path = "product-projections"
     }
     

--- a/Tests/Core/QueryEndpointTests.swift
+++ b/Tests/Core/QueryEndpointTests.swift
@@ -29,8 +29,8 @@ class QueryEndpointTests: XCTestCase {
 
         let predicate = "slug(en=\"michael-kors-bag-30T3GTVT7L-lightbrown\")"
 
-        TestProductProjections.query(predicates: [predicate], dictionaryResult: { result in
-            if let response = result.response, let count = response["count"] as? Int,
+        TestProductProjections.query(predicates: [predicate], result: { result in
+            if let response = result.json, let count = response["count"] as? Int,
                     let results = response["results"] as? [[String: AnyObject]],
                     let slug = results.first?["slug"] as? [String: String],
                     let enSlug = slug["en"], result.isSuccess && count == 1
@@ -46,8 +46,8 @@ class QueryEndpointTests: XCTestCase {
 
         let queryExpectation = expectation(description: "query expectation")
 
-        TestProductProjections.query(sort: ["name.en asc"], limit: 8, dictionaryResult: { result in
-            if let response = result.response, let count = response["count"] as? Int,
+        TestProductProjections.query(sort: ["name.en asc"], limit: 8, result: { result in
+            if let response = result.json, let count = response["count"] as? Int,
                     let results = response["results"] as? [[String: AnyObject]],
                     let name = results.first?["name"] as? [String: String], let enName = name["en"],
                     result.isSuccess && count == 8 && enName == "Alberto Guardiani – Slip on “Cherie”" {
@@ -62,8 +62,8 @@ class QueryEndpointTests: XCTestCase {
 
         let queryExpectation = expectation(description: "query expectation")
 
-        TestProductProjections.query(sort: ["name.en asc"], limit: 2, offset: 1, dictionaryResult: { result in
-            if let response = result.response, let count = response["count"] as? Int,
+        TestProductProjections.query(sort: ["name.en asc"], limit: 2, offset: 1, result: { result in
+            if let response = result.json, let count = response["count"] as? Int,
                     let results = response["results"] as? [[String: AnyObject]],
                     let name = results.first?["name"] as? [String: String], let enName = name["en"],
                     result.isSuccess && count == 2 && enName == "Bag DKNY beige" {
@@ -78,8 +78,8 @@ class QueryEndpointTests: XCTestCase {
 
         let queryExpectation = expectation(description: "query expectation")
 
-        TestProductProjections.query(sort: ["name.en asc", "slug.en asc"], limit: 1, dictionaryResult: { result in
-            if let response = result.response, let count = response["count"] as? Int,
+        TestProductProjections.query(sort: ["name.en asc", "slug.en asc"], limit: 1, result: { result in
+            if let response = result.json, let count = response["count"] as? Int,
                     let results = response["results"] as? [[String: AnyObject]],
                     let name = results.first?["name"] as? [String: String], let enName = name["en"],
                     result.isSuccess && count == 1 && enName == "Alberto Guardiani – Slip on “Cherie”" {
@@ -96,8 +96,8 @@ class QueryEndpointTests: XCTestCase {
 
         let predicate = "name(en=\"Bag “Jet Set Travel” Michael Kors light brown\")"
 
-        TestProductProjections.query(predicates: [predicate], expansion: ["productType"], dictionaryResult: { result in
-            if let response = result.response, let _ = response["count"] as? Int,
+        TestProductProjections.query(predicates: [predicate], expansion: ["productType"], result: { result in
+            if let response = result.json, let _ = response["count"] as? Int,
                     let results = response["results"] as? [[String: AnyObject]],
                     let productType = results.first?["productType"] as? [String: AnyObject],
                     let productTypeObject = productType["obj"] as? [String: AnyObject],

--- a/Tests/Core/QueryEndpointTests.swift
+++ b/Tests/Core/QueryEndpointTests.swift
@@ -8,7 +8,7 @@ import XCTest
 class QueryEndpointTests: XCTestCase {
 
     private class TestProductProjections: QueryEndpoint {
-        public typealias ResponseType = [String: Any]
+        public typealias ResponseType = ProductProjection
         static let path = "product-projections"
     }
     

--- a/Tests/Core/UpdateByKeyEndpointTests.swift
+++ b/Tests/Core/UpdateByKeyEndpointTests.swift
@@ -27,20 +27,20 @@ class UpdateByKeyEndpointTests: XCTestCase {
 
         let updateExpectation = expectation(description: "update expectation")
 
-        TestProductType.byKey("main", result: { result in
+        TestProductType.byKey("main", dictionaryResult: { result in
             if let response = result.response, let originalName = response["name"] as? String,
                     let version = response["version"] as? UInt, result.isSuccess && originalName == "main" {
 
                 var changeNameAction = ["action": "changeName", "name": "newName"]
 
-                TestProductType.updateByKey("main", version: version, actions: [changeNameAction], result: { result in
+                TestProductType.updateByKey("main", version: version, actions: [changeNameAction], dictionaryResult: { result in
                     if let response = result.response, let newName = response["name"] as? String,
                             let version = response["version"] as? UInt, result.isSuccess && newName == "newName" {
 
                         // Now revert back to the original name for the test data consistency reasons
                         changeNameAction["name"] = originalName
 
-                        TestProductType.updateByKey("main", version: version, actions: [changeNameAction], result: { result in
+                        TestProductType.updateByKey("main", version: version, actions: [changeNameAction], dictionaryResult: { result in
                             if let response = result.response, let name = response["name"] as? String, result.isSuccess && name == originalName {
                                 updateExpectation.fulfill()
                             }
@@ -57,13 +57,13 @@ class UpdateByKeyEndpointTests: XCTestCase {
 
         let updateExpectation = expectation(description: "update expectation")
 
-        TestProductType.byKey("main", result: { result in
+        TestProductType.byKey("main", dictionaryResult: { result in
             if let response = result.response, let version = response["version"] as? UInt,
                     let id = response["id"] as? String, result.isSuccess {
 
                 let changeNameAction = ["action": "changeName", "name": "newName"]
 
-                TestProductType.updateByKey("main", version: version + 1, actions: [changeNameAction], result: { result in
+                TestProductType.updateByKey("main", version: version + 1, actions: [changeNameAction], dictionaryResult: { result in
                     if let error = result.errors?.first as? CTError, result.statusCode == 409, case .concurrentModificationError(let reason, let currentVersion) = error,
                             reason.message!.hasPrefix("Object \(id) has a different version than expected.") && version == currentVersion {
                         updateExpectation.fulfill()
@@ -81,7 +81,7 @@ class UpdateByKeyEndpointTests: XCTestCase {
 
         let changeNameAction = ["action": "changeName", "name": "newName"]
 
-        TestProductType.updateByKey("incorrect_key", version: 1, actions: [changeNameAction], result: { result in            
+        TestProductType.updateByKey("incorrect_key", version: 1, actions: [changeNameAction], dictionaryResult: { result in            
             if let error = result.errors?.first as? CTError, result.statusCode == 404, case .resourceNotFoundError(let reason) = error,
                     reason.message == "The product-type with key 'incorrect_key' was not found." {
                 updateExpectation.fulfill()

--- a/Tests/Core/UpdateByKeyEndpointTests.swift
+++ b/Tests/Core/UpdateByKeyEndpointTests.swift
@@ -27,21 +27,21 @@ class UpdateByKeyEndpointTests: XCTestCase {
 
         let updateExpectation = expectation(description: "update expectation")
 
-        TestProductType.byKey("main", dictionaryResult: { result in
-            if let response = result.response, let originalName = response["name"] as? String,
+        TestProductType.byKey("main", result: { result in
+            if let response = result.json, let originalName = response["name"] as? String,
                     let version = response["version"] as? UInt, result.isSuccess && originalName == "main" {
 
                 var changeNameAction = ["action": "changeName", "name": "newName"]
 
-                TestProductType.updateByKey("main", version: version, actions: [changeNameAction], dictionaryResult: { result in
-                    if let response = result.response, let newName = response["name"] as? String,
+                TestProductType.updateByKey("main", version: version, actions: [changeNameAction], result: { result in
+                    if let response = result.json, let newName = response["name"] as? String,
                             let version = response["version"] as? UInt, result.isSuccess && newName == "newName" {
 
                         // Now revert back to the original name for the test data consistency reasons
                         changeNameAction["name"] = originalName
 
-                        TestProductType.updateByKey("main", version: version, actions: [changeNameAction], dictionaryResult: { result in
-                            if let response = result.response, let name = response["name"] as? String, result.isSuccess && name == originalName {
+                        TestProductType.updateByKey("main", version: version, actions: [changeNameAction], result: { result in
+                            if let response = result.json, let name = response["name"] as? String, result.isSuccess && name == originalName {
                                 updateExpectation.fulfill()
                             }
                         })
@@ -57,13 +57,13 @@ class UpdateByKeyEndpointTests: XCTestCase {
 
         let updateExpectation = expectation(description: "update expectation")
 
-        TestProductType.byKey("main", dictionaryResult: { result in
-            if let response = result.response, let version = response["version"] as? UInt,
+        TestProductType.byKey("main", result: { result in
+            if let response = result.json, let version = response["version"] as? UInt,
                     let id = response["id"] as? String, result.isSuccess {
 
                 let changeNameAction = ["action": "changeName", "name": "newName"]
 
-                TestProductType.updateByKey("main", version: version + 1, actions: [changeNameAction], dictionaryResult: { result in
+                TestProductType.updateByKey("main", version: version + 1, actions: [changeNameAction], result: { result in
                     if let error = result.errors?.first as? CTError, result.statusCode == 409, case .concurrentModificationError(let reason, let currentVersion) = error,
                             reason.message!.hasPrefix("Object \(id) has a different version than expected.") && version == currentVersion {
                         updateExpectation.fulfill()
@@ -81,7 +81,7 @@ class UpdateByKeyEndpointTests: XCTestCase {
 
         let changeNameAction = ["action": "changeName", "name": "newName"]
 
-        TestProductType.updateByKey("incorrect_key", version: 1, actions: [changeNameAction], dictionaryResult: { result in            
+        TestProductType.updateByKey("incorrect_key", version: 1, actions: [changeNameAction], result: { result in            
             if let error = result.errors?.first as? CTError, result.statusCode == 404, case .resourceNotFoundError(let reason) = error,
                     reason.message == "The product-type with key 'incorrect_key' was not found." {
                 updateExpectation.fulfill()

--- a/Tests/Core/UpdateByKeyEndpointTests.swift
+++ b/Tests/Core/UpdateByKeyEndpointTests.swift
@@ -8,7 +8,7 @@ import XCTest
 class UpdateByKeyEndpointTests: XCTestCase {
 
     private class TestProductType: ByKeyEndpoint, UpdateByKeyEndpoint {
-        public typealias ResponseType = ProductType
+        public typealias ResponseType = NoMapping
         static let path = "product-types"
     }
 

--- a/Tests/Core/UpdateByKeyEndpointTests.swift
+++ b/Tests/Core/UpdateByKeyEndpointTests.swift
@@ -8,6 +8,7 @@ import XCTest
 class UpdateByKeyEndpointTests: XCTestCase {
 
     private class TestProductType: ByKeyEndpoint, UpdateByKeyEndpoint {
+        public typealias ResponseType = [String: Any]
         static let path = "product-types"
     }
 

--- a/Tests/Core/UpdateByKeyEndpointTests.swift
+++ b/Tests/Core/UpdateByKeyEndpointTests.swift
@@ -8,7 +8,7 @@ import XCTest
 class UpdateByKeyEndpointTests: XCTestCase {
 
     private class TestProductType: ByKeyEndpoint, UpdateByKeyEndpoint {
-        public typealias ResponseType = [String: Any]
+        public typealias ResponseType = ProductType
         static let path = "product-types"
     }
 

--- a/Tests/Core/UpdateEndpointTests.swift
+++ b/Tests/Core/UpdateEndpointTests.swift
@@ -8,12 +8,12 @@ import XCTest
 class UpdateEndpointTests: XCTestCase {
 
     private class TestCart: UpdateEndpoint, CreateEndpoint {
-        public typealias ResponseType = [String: Any]
+        public typealias ResponseType = Cart
         static let path = "me/carts"
     }
 
     private class TestProductProjections: QueryEndpoint {
-        public typealias ResponseType = [String: Any]
+        public typealias ResponseType = ProductProjection
         static let path = "product-projections"
     }
 
@@ -43,7 +43,7 @@ class UpdateEndpointTests: XCTestCase {
 
                 let addLineItemAction: [String: Any] = ["action": "addLineItem", "productId": productId, "variantId": 1]
 
-                TestCart.create(["currency": "EUR"], result: { result in
+                TestCart.create(["currency": "EUR"], dictionaryResult: { result in
                     if let response = result.response, let id = response["id"] as? String, let version = response["version"] as? UInt, result.isSuccess {
                         TestCart.update(id, version: version, actions: [addLineItemAction], result: { result in
                             if let response = result.response, let updatedId = response["id"] as? String,
@@ -75,7 +75,7 @@ class UpdateEndpointTests: XCTestCase {
 
                 let addLineItemAction: [String: Any] = ["action": "addLineItem", "productId": productId, "variantId": 1]
 
-                TestCart.create(["currency": "EUR"], result: { result in
+                TestCart.create(["currency": "EUR"], dictionaryResult: { result in
                     if let response = result.response, let id = response["id"] as? String, let version = response["version"] as? UInt, result.isSuccess {
                         TestCart.update(id, version: version + 1, actions: [addLineItemAction], result: { result in
                             

--- a/Tests/Core/UpdateEndpointTests.swift
+++ b/Tests/Core/UpdateEndpointTests.swift
@@ -37,16 +37,16 @@ class UpdateEndpointTests: XCTestCase {
 
         AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
 
-        TestProductProjections.query(limit: 1, dictionaryResult: { result in
-            if let response = result.response, let results = response["results"] as? [[String: AnyObject]],
+        TestProductProjections.query(limit: 1, result: { result in
+            if let response = result.json, let results = response["results"] as? [[String: AnyObject]],
             let productId = results.first?["id"] as? String, result.isSuccess {
 
                 let addLineItemAction: [String: Any] = ["action": "addLineItem", "productId": productId, "variantId": 1]
 
-                TestCart.create(["currency": "EUR"], dictionaryResult: { result in
-                    if let response = result.response, let id = response["id"] as? String, let version = response["version"] as? UInt, result.isSuccess {
-                        TestCart.update(id, version: version, actions: [addLineItemAction], dictionaryResult: { result in
-                            if let response = result.response, let updatedId = response["id"] as? String,
+                TestCart.create(["currency": "EUR"], result: { result in
+                    if let response = result.json, let id = response["id"] as? String, let version = response["version"] as? UInt, result.isSuccess {
+                        TestCart.update(id, version: version, actions: [addLineItemAction], result: { result in
+                            if let response = result.json, let updatedId = response["id"] as? String,
                                     let newVersion = response["version"] as? UInt, result.isSuccess  && updatedId == id
                                     && newVersion > version {
                                 updateExpectation.fulfill()
@@ -69,15 +69,15 @@ class UpdateEndpointTests: XCTestCase {
 
         AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
 
-        TestProductProjections.query(limit: 1, dictionaryResult: { result in
-            if let response = result.response, let results = response["results"] as? [[String: AnyObject]],
+        TestProductProjections.query(limit: 1, result: { result in
+            if let response = result.json, let results = response["results"] as? [[String: AnyObject]],
                     let productId = results.first?["id"] as? String, result.isSuccess {
 
                 let addLineItemAction: [String: Any] = ["action": "addLineItem", "productId": productId, "variantId": 1]
 
-                TestCart.create(["currency": "EUR"], dictionaryResult: { result in
-                    if let response = result.response, let id = response["id"] as? String, let version = response["version"] as? UInt, result.isSuccess {
-                        TestCart.update(id, version: version + 1, actions: [addLineItemAction], dictionaryResult: { result in
+                TestCart.create(["currency": "EUR"], result: { result in
+                    if let response = result.json, let id = response["id"] as? String, let version = response["version"] as? UInt, result.isSuccess {
+                        TestCart.update(id, version: version + 1, actions: [addLineItemAction], result: { result in
                             
                             if let error = result.errors?.first as? CTError, result.statusCode == 409, case .concurrentModificationError(let reason, let currentVersion) = error,
                                     reason.message == "Object \(id) has a different version than expected. Expected: 2 - Actual: 1." && version == currentVersion {
@@ -101,7 +101,7 @@ class UpdateEndpointTests: XCTestCase {
 
         AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
 
-        TestCart.update("cddddddd-ffff-4b44-b5b0-004e7d4bc2dd", version: 1, actions: [], dictionaryResult: { result in
+        TestCart.update("cddddddd-ffff-4b44-b5b0-004e7d4bc2dd", version: 1, actions: [], result: { result in
             if let error = result.errors?.first as? CTError, result.statusCode == 404, case .resourceNotFoundError(let reason) = error,
                     reason.message == "The Cart with ID 'cddddddd-ffff-4b44-b5b0-004e7d4bc2dd' was not found." {
                 updateExpectation.fulfill()

--- a/Tests/Core/UpdateEndpointTests.swift
+++ b/Tests/Core/UpdateEndpointTests.swift
@@ -37,7 +37,7 @@ class UpdateEndpointTests: XCTestCase {
 
         AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
 
-        TestProductProjections.query(limit: 1, result: { result in
+        TestProductProjections.query(limit: 1, dictionaryResult: { result in
             if let response = result.response, let results = response["results"] as? [[String: AnyObject]],
             let productId = results.first?["id"] as? String, result.isSuccess {
 
@@ -45,7 +45,7 @@ class UpdateEndpointTests: XCTestCase {
 
                 TestCart.create(["currency": "EUR"], dictionaryResult: { result in
                     if let response = result.response, let id = response["id"] as? String, let version = response["version"] as? UInt, result.isSuccess {
-                        TestCart.update(id, version: version, actions: [addLineItemAction], result: { result in
+                        TestCart.update(id, version: version, actions: [addLineItemAction], dictionaryResult: { result in
                             if let response = result.response, let updatedId = response["id"] as? String,
                                     let newVersion = response["version"] as? UInt, result.isSuccess  && updatedId == id
                                     && newVersion > version {
@@ -69,7 +69,7 @@ class UpdateEndpointTests: XCTestCase {
 
         AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
 
-        TestProductProjections.query(limit: 1, result: { result in
+        TestProductProjections.query(limit: 1, dictionaryResult: { result in
             if let response = result.response, let results = response["results"] as? [[String: AnyObject]],
                     let productId = results.first?["id"] as? String, result.isSuccess {
 
@@ -77,7 +77,7 @@ class UpdateEndpointTests: XCTestCase {
 
                 TestCart.create(["currency": "EUR"], dictionaryResult: { result in
                     if let response = result.response, let id = response["id"] as? String, let version = response["version"] as? UInt, result.isSuccess {
-                        TestCart.update(id, version: version + 1, actions: [addLineItemAction], result: { result in
+                        TestCart.update(id, version: version + 1, actions: [addLineItemAction], dictionaryResult: { result in
                             
                             if let error = result.errors?.first as? CTError, result.statusCode == 409, case .concurrentModificationError(let reason, let currentVersion) = error,
                                     reason.message == "Object \(id) has a different version than expected. Expected: 2 - Actual: 1." && version == currentVersion {
@@ -101,7 +101,7 @@ class UpdateEndpointTests: XCTestCase {
 
         AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
 
-        TestCart.update("cddddddd-ffff-4b44-b5b0-004e7d4bc2dd", version: 1, actions: [], result: { result in
+        TestCart.update("cddddddd-ffff-4b44-b5b0-004e7d4bc2dd", version: 1, actions: [], dictionaryResult: { result in
             if let error = result.errors?.first as? CTError, result.statusCode == 404, case .resourceNotFoundError(let reason) = error,
                     reason.message == "The Cart with ID 'cddddddd-ffff-4b44-b5b0-004e7d4bc2dd' was not found." {
                 updateExpectation.fulfill()

--- a/Tests/Core/UpdateEndpointTests.swift
+++ b/Tests/Core/UpdateEndpointTests.swift
@@ -8,10 +8,12 @@ import XCTest
 class UpdateEndpointTests: XCTestCase {
 
     private class TestCart: UpdateEndpoint, CreateEndpoint {
+        public typealias ResponseType = [String: Any]
         static let path = "me/carts"
     }
 
     private class TestProductProjections: QueryEndpoint {
+        public typealias ResponseType = [String: Any]
         static let path = "product-projections"
     }
 

--- a/Tests/Core/UpdateEndpointTests.swift
+++ b/Tests/Core/UpdateEndpointTests.swift
@@ -13,7 +13,7 @@ class UpdateEndpointTests: XCTestCase {
     }
 
     private class TestProductProjections: QueryEndpoint {
-        public typealias ResponseType = ProductProjection
+        public typealias ResponseType = NoMapping
         static let path = "product-projections"
     }
 

--- a/Tests/Endpoints/CartTests.swift
+++ b/Tests/Endpoints/CartTests.swift
@@ -26,11 +26,11 @@ class CartTests: XCTestCase {
 
         AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
 
-        Cart.create(["currency": "EUR"], dictionaryResult: { result in
-            if let response = result.response, let cartState = response["cartState"] as? String, let id = response["id"] as? String,
+        Cart.create(["currency": "EUR"], result: { result in
+            if let response = result.json, let cartState = response["cartState"] as? String, let id = response["id"] as? String,
                     result.isSuccess && cartState == "Active" {
-                Cart.active(dictionaryResult: { result in
-                    if let response = result.response, let activeCartId = response["id"] as? String, activeCartId == id {
+                Cart.active(result: { result in
+                    if let response = result.json, let activeCartId = response["id"] as? String, activeCartId == id {
                         activeCartExpectation.fulfill()
                     }
                 })

--- a/Tests/Endpoints/CartTests.swift
+++ b/Tests/Endpoints/CartTests.swift
@@ -26,10 +26,10 @@ class CartTests: XCTestCase {
 
         AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
 
-        Cart.create(["currency": "EUR"], result: { result in
+        Cart.create(["currency": "EUR"], dictionaryResult: { result in
             if let response = result.response, let cartState = response["cartState"] as? String, let id = response["id"] as? String,
                     result.isSuccess && cartState == "Active" {
-                Cart.active(result: { result in
+                Cart.active(dictionaryResult: { result in
                     if let response = result.response, let activeCartId = response["id"] as? String, activeCartId == id {
                         activeCartExpectation.fulfill()
                     }

--- a/Tests/Endpoints/CartTests.swift
+++ b/Tests/Endpoints/CartTests.swift
@@ -18,6 +18,27 @@ class CartTests: XCTestCase {
         super.tearDown()
     }
     
+    func testRetrieveActiveCart2() {
+        let activeCartExpectation = expectation(description: "active cart expectation")
+        
+        let username = "swift.sdk.test.user2@commercetools.com"
+        let password = "password"
+        
+        AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
+        
+        Cart.create(["currency": "EUR"], dictionaryResult: { result in
+            if let response = result.response, let cartState = response["cartState"] as? String, let _ = response["id"] as? String,
+                result.isSuccess && cartState == "Active" {
+                Cart.active(dictionaryResult: { result in
+                    print(result)
+                    activeCartExpectation.fulfill()
+                })
+            }
+        })
+        
+        waitForExpectations(timeout: 10, handler: nil)
+    }
+    
     func testRetrieveActiveCart() {
         let activeCartExpectation = expectation(description: "active cart expectation")
 

--- a/Tests/Endpoints/CartTests.swift
+++ b/Tests/Endpoints/CartTests.swift
@@ -17,28 +17,7 @@ class CartTests: XCTestCase {
         cleanPersistedTokens()
         super.tearDown()
     }
-    
-    func testRetrieveActiveCart2() {
-        let activeCartExpectation = expectation(description: "active cart expectation")
-        
-        let username = "swift.sdk.test.user2@commercetools.com"
-        let password = "password"
-        
-        AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
-        
-        Cart.create(["currency": "EUR"], dictionaryResult: { result in
-            if let response = result.response, let cartState = response["cartState"] as? String, let _ = response["id"] as? String,
-                result.isSuccess && cartState == "Active" {
-                Cart.active(dictionaryResult: { result in
-                    print(result)
-                    activeCartExpectation.fulfill()
-                })
-            }
-        })
-        
-        waitForExpectations(timeout: 10, handler: nil)
-    }
-    
+
     func testRetrieveActiveCart() {
         let activeCartExpectation = expectation(description: "active cart expectation")
 
@@ -60,5 +39,5 @@ class CartTests: XCTestCase {
 
         waitForExpectations(timeout: 10, handler: nil)
     }
-    
+
 }

--- a/Tests/Endpoints/CustomerTests.swift
+++ b/Tests/Endpoints/CustomerTests.swift
@@ -9,6 +9,7 @@ import Alamofire
 class CustomerTests: XCTestCase {
 
     private class TestCustomer: QueryEndpoint {
+        public typealias ResponseType = [String: Any]
         static let path = "customers"
     }
 

--- a/Tests/Endpoints/CustomerTests.swift
+++ b/Tests/Endpoints/CustomerTests.swift
@@ -213,7 +213,7 @@ class CustomerTests: XCTestCase {
         AuthManager.sharedInstance.token { token, error in
             guard let token = token, let path = TestCustomer.fullPath else { return }
             
-            let customerResult: ((Commercetools.Result<Customer>) -> Void) = { result in
+            let customerResult: ((Commercetools.Result<NoMapping>) -> Void) = { result in
                 if let response = result.json, let token = response["value"] as? String, result.isSuccess {
                     
                     // Now confirm reset password token with regular mobile client scope
@@ -258,7 +258,7 @@ class CustomerTests: XCTestCase {
                 if let response = result.json, let results = response["results"] as? [[String: AnyObject]],
                         let id = results.first?["id"] as? String, result.isSuccess {
                     
-                    let customerResult: ((Commercetools.Result<Customer>) -> Void) = { result in
+                    let customerResult: ((Commercetools.Result<NoMapping>) -> Void) = { result in
                         if let response = result.json, let token = response["value"] as? String, result.isSuccess {
                             
                             // Confirm email verification token with regular mobile client scope

--- a/Tests/Endpoints/CustomerTests.swift
+++ b/Tests/Endpoints/CustomerTests.swift
@@ -33,7 +33,7 @@ class CustomerTests: XCTestCase {
         AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
 
         Customer.profile { result in
-            if let response = result.response, let _ = response["firstName"] as? String,
+            if let response = result.json, let _ = response["firstName"] as? String,
                     let _ = response["lastName"] as? String, result.isSuccess {
                 retrieveProfileExpectation.fulfill()
             }
@@ -68,14 +68,14 @@ class CustomerTests: XCTestCase {
         let signupDraft = ["email": username, "password": "password"]
 
         Customer.signup(signupDraft, result: { result in
-            if let response = result.response, let customer = response["customer"] as? [String: Any],
+            if let response = result.json, let customer = response["customer"] as? [String: Any],
                     let email = customer["email"] as? String, let version = customer["version"] as? UInt, result.isSuccess
                     && email == username {
                 createProfileExpectation.fulfill()
 
                 AuthManager.sharedInstance.loginUser(username, password: "password", completionHandler: {_ in})
                 Customer.delete(version: version, result: { result in
-                    if let response = result.response, let email = response["email"] as? String, result.isSuccess
+                    if let response = result.json, let email = response["email"] as? String, result.isSuccess
                             && email == username {
                         deleteProfileExpectation.fulfill()
                     }
@@ -131,9 +131,9 @@ class CustomerTests: XCTestCase {
         var setFirstNameAction: [String: Any] = ["action": "setFirstName", "firstName": "newName"]
 
         Customer.profile { result in
-            if let response = result.response, let version = response["version"] as? UInt, result.isSuccess {
+            if let response = result.json, let version = response["version"] as? UInt, result.isSuccess {
                 Customer.update(version: version, actions: [setFirstNameAction], result: { result in
-                    if let response = result.response, let version = response["version"] as? UInt,
+                    if let response = result.json, let version = response["version"] as? UInt,
                             let firstName = response["firstName"] as? String, result.isSuccess
                             && firstName == "newName" {
 
@@ -141,7 +141,7 @@ class CustomerTests: XCTestCase {
                         setFirstNameAction["firstName"] = "Test"
 
                         Customer.update(version: version, actions: [setFirstNameAction], result: { result in
-                            if let response = result.response, let firstName = response["firstName"] as? String, result.isSuccess && firstName == "Test" {
+                            if let response = result.json, let firstName = response["firstName"] as? String, result.isSuccess && firstName == "Test" {
                                 updateProfileExpectation.fulfill()
                             }
                         })
@@ -181,10 +181,10 @@ class CustomerTests: XCTestCase {
         AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
 
         Customer.profile { result in
-            if let response = result.response, let version = response["version"] as? UInt, result.isSuccess {
+            if let response = result.json, let version = response["version"] as? UInt, result.isSuccess {
 
                 Customer.changePassword(currentPassword: password, newPassword: "newPassword", version: version, result: { result in
-                    if let response = result.response, let version = response["version"] as? UInt, result.isSuccess {
+                    if let response = result.json, let version = response["version"] as? UInt, result.isSuccess {
 
                         // Now revert the password change
                         Customer.changePassword(currentPassword: "newPassword", newPassword: password, version: version, result: { result in
@@ -213,14 +213,14 @@ class CustomerTests: XCTestCase {
         AuthManager.sharedInstance.token { token, error in
             guard let token = token, let path = TestCustomer.fullPath else { return }
             
-            let customerResult: ((Commercetools.Result<[String: Any]>) -> Void) = { result in
-                if let response = result.response, let token = response["value"] as? String, result.isSuccess {
+            let customerResult: ((Commercetools.Result<Customer>) -> Void) = { result in
+                if let response = result.json, let token = response["value"] as? String, result.isSuccess {
                     
                     // Now confirm reset password token with regular mobile client scope
                     self.setupTestConfiguration()
                     
                     Customer.resetPassword(token: token, newPassword: "password", result: { result in
-                        if let response = result.response, let email = response["email"] as? String, result.isSuccess
+                        if let response = result.json, let email = response["email"] as? String, result.isSuccess
                             && email == username {
                             resetPasswordExpectation.fulfill()
                         }
@@ -254,19 +254,19 @@ class CustomerTests: XCTestCase {
             }
 
             // First query for the UUID of the user we want to activate
-            TestCustomer.query(predicates: ["email=\"\(username)\""], dictionaryResult: { result in
-                if let response = result.response, let results = response["results"] as? [[String: AnyObject]],
+            TestCustomer.query(predicates: ["email=\"\(username)\""], result: { result in
+                if let response = result.json, let results = response["results"] as? [[String: AnyObject]],
                         let id = results.first?["id"] as? String, result.isSuccess {
                     
-                    let customerResult: ((Commercetools.Result<[String: Any]>) -> Void) = { result in
-                        if let response = result.response, let token = response["value"] as? String, result.isSuccess {
+                    let customerResult: ((Commercetools.Result<Customer>) -> Void) = { result in
+                        if let response = result.json, let token = response["value"] as? String, result.isSuccess {
                             
                             // Confirm email verification token with regular mobile client scope
                             self.setupTestConfiguration()
                             AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
                             
                             Customer.verifyEmail(token: token, result: { result in
-                                if let response = result.response, let email = response["email"] as? String, result.isSuccess
+                                if let response = result.json, let email = response["email"] as? String, result.isSuccess
                                     && email == username {
                                     resetPasswordExpectation.fulfill()
                                 }

--- a/Tests/Endpoints/CustomerTests.swift
+++ b/Tests/Endpoints/CustomerTests.swift
@@ -254,7 +254,7 @@ class CustomerTests: XCTestCase {
             }
 
             // First query for the UUID of the user we want to activate
-            TestCustomer.query(predicates: ["email=\"\(username)\""], result: { result in
+            TestCustomer.query(predicates: ["email=\"\(username)\""], dictionaryResult: { result in
                 if let response = result.response, let results = response["results"] as? [[String: AnyObject]],
                         let id = results.first?["id"] as? String, result.isSuccess {
                     

--- a/Tests/Endpoints/ProductProjectionTests.swift
+++ b/Tests/Endpoints/ProductProjectionTests.swift
@@ -70,7 +70,7 @@ class ProductProjectionTests: XCTestCase {
 
         let searchExpectation = expectation(description: "search expectation")
 
-        TestTaxCategory.query(limit: 1, result: { result in
+        TestTaxCategory.query(limit: 1, dictionaryResult: { result in
             if let response = result.response, let results = response["results"] as? [[String: AnyObject]],
                     let taxCategoryId = results.first?["id"] as? String, result.isSuccess {
 
@@ -129,7 +129,7 @@ class ProductProjectionTests: XCTestCase {
                     let results = response["results"] as? [[String: AnyObject]],
                     let id = results.first?["id"] as? String, result.isSuccess && count == 1 {
 
-                ProductProjection.byId(id, result: { result in
+                ProductProjection.byId(id, dictionaryResult: { result in
                     if let response = result.response, let retrievedId = response["id"] as? String, result.isSuccess
                             && retrievedId == id {
                         byIdExpectation.fulfill()

--- a/Tests/Endpoints/ProductProjectionTests.swift
+++ b/Tests/Endpoints/ProductProjectionTests.swift
@@ -3,13 +3,16 @@
 //
 
 import XCTest
+import ObjectMapper
 @testable import Commercetools
 
 class ProductProjectionTests: XCTestCase {
 
-    private class TestTaxCategory: QueryEndpoint {
-        public typealias ResponseType = [String: Any]
+    private class TestTaxCategory: QueryEndpoint, Mappable {
+        public typealias ResponseType = TestTaxCategory
         static let path = "tax-categories"
+        required init?(map: Map) {}
+        func mapping(map: Map) {}
     }
 
     override func setUp() {

--- a/Tests/Endpoints/ProductProjectionTests.swift
+++ b/Tests/Endpoints/ProductProjectionTests.swift
@@ -8,6 +8,7 @@ import XCTest
 class ProductProjectionTests: XCTestCase {
 
     private class TestTaxCategory: QueryEndpoint {
+        public typealias ResponseType = [String: Any]
         static let path = "tax-categories"
     }
 

--- a/Tests/Endpoints/ProductProjectionTests.swift
+++ b/Tests/Endpoints/ProductProjectionTests.swift
@@ -32,7 +32,7 @@ class ProductProjectionTests: XCTestCase {
 
         ProductProjection.search(sort: ["name.en asc"], limit: 10, lang: Locale(identifier: "en"),
                                  text: "Michael Kors", result: { result in
-            if let response = result.response, let total = response["total"] as? Int,
+            if let response = result.json, let total = response["total"] as? Int,
                     let _ = response["results"] as? [[String: AnyObject]], result.isSuccess && total == 103 {
                 searchExpectation.fulfill()
             }
@@ -47,7 +47,7 @@ class ProductProjectionTests: XCTestCase {
 
         ProductProjection.search(staged: true, filterFacets: "variants.attributes.color.key:\"red\"",
                 facets: ["variants.attributes.color.key", "variants.attributes.commonSize.key"], result: { result in
-            if let response = result.response, let facets = response["facets"] as? [String: AnyObject],
+            if let response = result.json, let facets = response["facets"] as? [String: AnyObject],
                     let colorFacets = facets["variants.attributes.color.key"] as? [String: AnyObject],
                     let colorFacetsTotal = colorFacets["total"] as? UInt, let colorTerms = colorFacets["terms"] as? [[String: AnyObject]],
                     let blueTerm = colorTerms.first!["term"] as? String, let blueCount = colorTerms.first!["count"] as? UInt,
@@ -70,14 +70,14 @@ class ProductProjectionTests: XCTestCase {
 
         let searchExpectation = expectation(description: "search expectation")
 
-        TestTaxCategory.query(limit: 1, dictionaryResult: { result in
-            if let response = result.response, let results = response["results"] as? [[String: AnyObject]],
+        TestTaxCategory.query(limit: 1, result: { result in
+            if let response = result.json, let results = response["results"] as? [[String: AnyObject]],
                     let taxCategoryId = results.first?["id"] as? String, result.isSuccess {
 
                 ProductProjection.search(staged: true, limit: 1, filterQuery: "taxCategory.id:\"\(taxCategoryId)\"",
                         result: { result in
 
-                    if let response = result.response, let total = response["total"] as? Int,
+                    if let response = result.json, let total = response["total"] as? Int,
                             let _ = response["results"] as? [[String: AnyObject]], result.isSuccess && total == 999 {
                         searchExpectation.fulfill()
                     }
@@ -94,7 +94,7 @@ class ProductProjectionTests: XCTestCase {
 
         ProductProjection.search(expansion: ["productType"], limit: 10, lang: Locale(identifier: "en"), text: "Michael Kors",
                 result: { result in
-                    if let response = result.response, let _ = response["count"] as? Int,
+                    if let response = result.json, let _ = response["count"] as? Int,
                             let results = response["results"] as? [[String: AnyObject]],
                             let productType = results.first?["productType"] as? [String: AnyObject],
                             let productTypeObject = productType["obj"] as? [String: AnyObject], result.isSuccess
@@ -111,7 +111,7 @@ class ProductProjectionTests: XCTestCase {
         let suggestExpectation = expectation(description: "suggest expectation")
 
         ProductProjection.suggest(lang: Locale(identifier: "en"), searchKeywords: "michael", result: { result in
-            if let response = result.response, let keywords = response["searchKeywords.en"] as? [[String: AnyObject]],
+            if let response = result.json, let keywords = response["searchKeywords.en"] as? [[String: AnyObject]],
             let _ = keywords.first?["text"] as? String, result.isSuccess {
                 suggestExpectation.fulfill()
             }
@@ -125,12 +125,12 @@ class ProductProjectionTests: XCTestCase {
         let byIdExpectation = expectation(description: "byId expectation")
 
         ProductProjection.query(limit: 1, result: { result in
-            if let response = result.response, let count = response["count"] as? Int,
+            if let response = result.json, let count = response["count"] as? Int,
                     let results = response["results"] as? [[String: AnyObject]],
                     let id = results.first?["id"] as? String, result.isSuccess && count == 1 {
 
-                ProductProjection.byId(id, dictionaryResult: { result in
-                    if let response = result.response, let retrievedId = response["id"] as? String, result.isSuccess
+                ProductProjection.byId(id, result: { result in
+                    if let response = result.json, let retrievedId = response["id"] as? String, result.isSuccess
                             && retrievedId == id {
                         byIdExpectation.fulfill()
                     }
@@ -162,7 +162,7 @@ class ProductProjectionTests: XCTestCase {
         let predicate = "slug(en=\"michael-kors-bag-30T3GTVT7L-lightbrown\")"
 
         ProductProjection.query(predicates: [predicate], result: { result in
-            if let response = result.response, let count = response["count"] as? Int,
+            if let response = result.json, let count = response["count"] as? Int,
             let results = response["results"] as? [[String: AnyObject]],
             let slug = results.first?["slug"] as? [String: String],
             let enSlug = slug["en"], result.isSuccess && count == 1
@@ -179,7 +179,7 @@ class ProductProjectionTests: XCTestCase {
         let queryExpectation = expectation(description: "query expectation")
 
         ProductProjection.query(sort: ["name.en asc"], limit: 8, result: { result in
-            if let response = result.response, let count = response["count"] as? Int,
+            if let response = result.json, let count = response["count"] as? Int,
             let results = response["results"] as? [[String: AnyObject]],
             let name = results.first?["name"] as? [String: String], let enName = name["en"],
                     result.isSuccess && count == 8 && enName == "Alberto Guardiani – Slip on “Cherie”" {
@@ -195,7 +195,7 @@ class ProductProjectionTests: XCTestCase {
         let queryExpectation = expectation(description: "query expectation")
 
         ProductProjection.query(sort: ["name.en asc"], limit: 2, offset: 1, result: { result in
-            if let response = result.response, let count = response["count"] as? Int,
+            if let response = result.json, let count = response["count"] as? Int,
             let results = response["results"] as? [[String: AnyObject]],
             let name = results.first?["name"] as? [String: String], let enName = name["en"],
                     result.isSuccess && count == 2 && enName == "Bag DKNY beige" {
@@ -211,7 +211,7 @@ class ProductProjectionTests: XCTestCase {
         let queryExpectation = expectation(description: "query expectation")
 
         ProductProjection.query(sort: ["name.en asc", "slug.en asc"], limit: 1, result: { result in
-            if let response = result.response, let count = response["count"] as? Int,
+            if let response = result.json, let count = response["count"] as? Int,
             let results = response["results"] as? [[String: AnyObject]],
             let name = results.first?["name"] as? [String: String], let enName = name["en"],
                     result.isSuccess && count == 1 && enName == "Alberto Guardiani – Slip on “Cherie”" {
@@ -229,7 +229,7 @@ class ProductProjectionTests: XCTestCase {
         let predicate = "name(en=\"Bag “Jet Set Travel” Michael Kors light brown\")"
 
         ProductProjection.query(predicates: [predicate], expansion: ["productType"], result: { result in
-            if let response = result.response, let _ = response["count"] as? Int,
+            if let response = result.json, let _ = response["count"] as? Int,
                     let results = response["results"] as? [[String: AnyObject]],
                     let productType = results.first?["productType"] as? [String: AnyObject],
                     let productTypeObject = productType["obj"] as? [String: AnyObject], result.isSuccess


### PR DESCRIPTION
_Note:_ Tests are still being added for this feature.

Besides introducing a lot of models related to cart endpoint, this PR introduces support for models across endpoints, specifically for: `QueryEndpoint, ByIdEndpoint, CreateEndpoint, UpdateEndpoint, DeleteEndpoint`.

We'll also be leaving an option for each endpoint for the SDK users to consume raw dictionary, in case of an API change, etc. In general, for each endpoint / action, we have 2 possible `result` handlers, one containing model and the other one dictionary response.
Just to quickly illustrate that with active cart:

Dictionary:
```swift
Cart.active(dictionaryResult: { result in
    if let response = result.response, let activeCartId = response["id"] {
        // The response is an instance of Dictionary type
    }
})
```
Model:
```swift
Cart.active(result: { result in
    if let cart = result.response, result.isSuccess {
        // cart.cartState == .active would of course return true
    }
})
```

Another important thing to note here is that `Draft` models aren't included. I thought this PR got too many changes, so for the sake of reviewing (and implementation), I was thinking to add `Draft` models after this one gets merged.
@cneijenhuis WDYT?