### PR TITLE
Closes #87 Add anonymous cart sign in mode

### DIFF
--- a/Commercetools.xcodeproj/project.pbxproj
+++ b/Commercetools.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		210BEA1170C392AA36907B63 /* StateRole.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE9449BBF4A8DD0B7B09E /* StateRole.swift */; };
 		210BEA16377561C1FC741F28 /* CreateEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEF918E99658EE26EA2EE /* CreateEndpointTests.swift */; };
 		210BEA9A3DDB3216E94A6152 /* Zone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEF391627F9DE1730CC16 /* Zone.swift */; };
+		210BEAB55406B7D50666F3D5 /* AnonymousCartSignInMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEA8C191A3D896D2DF133 /* AnonymousCartSignInMode.swift */; };
 		210BEAC43656B07788455DBF /* ReturnInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEAAA0DE6D66C5D909149 /* ReturnInfo.swift */; };
 		210BEAF3789CFF3898152D79 /* Location.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE4E18D39AAC4D717A979 /* Location.swift */; };
 		210BEB5CFFA25C9B2F702751 /* PaymentMethodInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEBF406AB4C5BABCAA58B /* PaymentMethodInfo.swift */; };
@@ -208,6 +209,7 @@
 		210BEA38F1A3754058F16FDC /* TaxMode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaxMode.swift; sourceTree = "<group>"; };
 		210BEA757C72C7352C15B276 /* CartDraft.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CartDraft.swift; sourceTree = "<group>"; };
 		210BEA79B4FA8CDFF3BA78D5 /* DiscountCodeState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiscountCodeState.swift; sourceTree = "<group>"; };
+		210BEA8C191A3D896D2DF133 /* AnonymousCartSignInMode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnonymousCartSignInMode.swift; sourceTree = "<group>"; };
 		210BEA9FB39CC0B4C382E087 /* Endpoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Endpoint.swift; sourceTree = "<group>"; };
 		210BEAAA0DE6D66C5D909149 /* ReturnInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReturnInfo.swift; sourceTree = "<group>"; };
 		210BEAABCBDF178FC0D01D3C /* Channel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Channel.swift; sourceTree = "<group>"; };
@@ -407,6 +409,7 @@
 				210BEEA9D57C44CBFA8EA866 /* ExternalLineItemTotalPrice.swift */,
 				210BE61CBA50D35A74FCD59B /* ResourceIdentifier.swift */,
 				210BE4D26AAC72DDCA7C600D /* CustomerUpdateAction.swift */,
+				210BEA8C191A3D896D2DF133 /* AnonymousCartSignInMode.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -808,6 +811,7 @@
 				210BE59FD6B10BFCB06869D9 /* ExternalLineItemTotalPrice.swift in Sources */,
 				210BE324CAFE1123C16146FD /* ResourceIdentifier.swift in Sources */,
 				210BEC81E5A96322CBA1BAA4 /* CustomerUpdateAction.swift in Sources */,
+				210BEAB55406B7D50666F3D5 /* AnonymousCartSignInMode.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ If at some point you wish to login the user, that can be achieved using `loginUs
 let username = "swift.sdk.test.user@commercetools.com"
 let password = "password"
 
-Commercetools.loginUser(username, password: password, completionHandler: { error in
-    if let error = error as? CTError, case .accessTokenRetrievalFailed(let reason) = error {
+Commercetools.loginCustomer(username, password: password, completionHandler: { result in
+    if let error = result.errors?.first as? CTError, case .accessTokenRetrievalFailed(let reason) = error {
         // Handle error, and possibly get some more information from reason.message
     }
 })
@@ -106,7 +106,7 @@ Commercetools.loginUser(username, password: password, completionHandler: { error
 Similarly, after logging out, all further interactions continue to use new anonymous user token.
 
 ```swift
-Commercetools.logoutUser()
+Commercetools.logoutCustomer()
 ```
 
 Access and refresh tokens are being preserved across app launches. In order to inspect whether it's currently handling authenticated or anonymous user, `authState` property should be used:
@@ -118,13 +118,14 @@ if Commercetools.authState == .plainToken {
 ```
 In order for your app to support anonymous session, you should set the `anonymousSession` bool property in your configuration `.plist` file to `true`. Additionally, it is possible to override this setting, and also provide optional custom `anonymous_id` (for metrics and tracking purposes) by invoking:
 ```swift
-if Commercetools.obtainAnonymousToken(usingSession: true, anonymousId: "some-custom-id", completionHandler: { error in
-     if error == nil {
+Commercetools.obtainAnonymousToken(usingSession: true, anonymousId: "some-custom-id", completionHandler: { error in
+    if error == nil {
         // It is possible for token retrieval to fail, e.g custom token ID has already been taken,
         // in which case reason.message from the returned CTError instance is set to the anonymousId is already in use.
-     }
- })
+    }
+})
 ```
+When an anonymous sessions ends with a sign up or a login, carts and orders are migrated to the customer, and `CustomerSignInResult` is returned, providing access to both customer profile, and the currently active cart. For the login operation, you can define how to migrate line items from the currently active cart, by explicitly specifying one of two `AnonymousCartSignInMode` values: `.mergeWithExistingCustomerCart` or `.useAsNewActiveCustomerCart`. 
 
 ## Consuming Commercetools Endpoints
 

--- a/Source/AuthManager.swift
+++ b/Source/AuthManager.swift
@@ -139,7 +139,7 @@ open class AuthManager {
         - parameter password:           The user's password.
         - parameter completionHandler:  The code to be executed once the token fetching completes.
     */
-    open func loginUser(_ username: String, password: String, completionHandler: @escaping (Error?) -> Void) {
+    open func login(username: String, password: String, completionHandler: @escaping (Error?) -> Void) {
         // Process all token requests using private serial queue to avoid issues with race conditions
         // when multiple credentials / login requests can lead auth manager in an unpredictable state
         serialQueue.async(execute: {

--- a/Source/CTError.swift
+++ b/Source/CTError.swift
@@ -20,10 +20,10 @@ public enum CTError: Error {
     public struct FailureReason {
 
         /// The error message returned by the API.
-        let message: String?
+        public let message: String?
 
         /// The detailed description when returned as a value of the `detailedErrorMessage` response field.
-        let details: String?
+        public let details: String?
     }
     
     case configurationValidationFailed

--- a/Source/Commercetools.swift
+++ b/Source/Commercetools.swift
@@ -43,7 +43,7 @@ public var authState: AuthManager.TokenState {
     - parameter completionHandler:  The code to be executed once the token fetching completes.
 */
 public func loginUser(_ username: String, password: String, completionHandler: @escaping (Error?) -> Void) {
-    AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: completionHandler)
+    AuthManager.sharedInstance.login(username: username, password: password, completionHandler: completionHandler)
 }
 
 /**

--- a/Source/Commercetools.swift
+++ b/Source/Commercetools.swift
@@ -2,7 +2,7 @@
 // Copyright (c) 2016 Commercetools. All rights reserved.
 //
 
-import Foundation
+import ObjectMapper
 
 // MARK: - Configuration
 
@@ -33,26 +33,77 @@ public var authState: AuthManager.TokenState {
 }
 
 /**
-    This method should be used for user login. After successful login the new auth token is used for all
+    This method should be used for customer login. After successful login the new auth token is used for all
     further requests with Commercetools services.
-    In case this method is called before previously logging user out, it will automatically logout (i.e remove
+    In case this method is called before previously logging customer out, it will automatically logout (i.e remove
     previously stored tokens).
 
-    - parameter username:           The user's username.
-    - parameter password:           The user's password.
+    - parameter username:               The user's username.
+    - parameter password:               The user's password.
     - parameter activeCartSignInMode:   Optional sign in mode, specifying whether the cart line items should be merged.
-    - parameter completionHandler:  The code to be executed once the token fetching completes.
+    - parameter completionHandler:      The code to be executed once the token fetching completes.
 */
-public func login(username: String, password: String, activeCartSignInMode: AnonymousCartSignInMode? = nil, completionHandler: @escaping (Error?) -> Void) {
-    AuthManager.sharedInstance.login(username: username, password: password, activeCartSignInMode: activeCartSignInMode, completionHandler: completionHandler)
+public func loginCustomer(username: String, password: String, activeCartSignInMode: AnonymousCartSignInMode? = nil,
+                          result: @escaping (Result<CustomerSignInResult>) -> Void) {
+    if authState == .customerToken {
+        logoutCustomer()
+    }
+
+    // If the user is logging after an anonymous session, `/me/login` endpoint is triggered before obtaining
+    // access and refresh tokens, so that carts and orders can be migrated
+    Customer.login(username: username, password: password, activeCartSignInMode: activeCartSignInMode) { loginResult in
+        if loginResult.isFailure {
+            result(loginResult)
+        } else {
+            AuthManager.sharedInstance.loginCustomer(username: username, password: password) { error in
+                if let error = error {
+                    result(.failure(nil, [error]))
+                } else {
+                    result(loginResult)
+                }
+            }
+        }
+    }
+}
+
+/**
+    Creates new customer with specified profile.
+
+    - parameter profile:                  Draft of the customer profile to be created.
+    - parameter result:                   The code to be executed after processing the response.
+*/
+public func signUpCustomer(_ profile: CustomerDraft, result: @escaping (Result<CustomerSignInResult>) -> Void) {
+    signUpCustomer(Mapper<CustomerDraft>().toJSON(profile), result: result)
+}
+
+/**
+    Creates new customer with specified profile.
+
+    - parameter profile:                  Dictionary representation of the draft customer profile to be created.
+    - parameter result:                   The code to be executed after processing the response.
+*/
+public func signUpCustomer(_ profile: [String: Any], result: @escaping (Result<CustomerSignInResult>) -> Void) {
+    Customer.signUp(profile, result: { signUpResult in
+        if signUpResult.isFailure {
+            result(signUpResult)
+        } else if let username = signUpResult.model?.customer?.email, let password = profile["password"] as? String {
+            AuthManager.sharedInstance.loginCustomer(username: username, password: password) { error in
+                if let error = error {
+                    result(.failure(nil, [error]))
+                } else {
+                    result(signUpResult)
+                }
+            }
+        }
+    })
 }
 
 /**
     This method will clear all tokens both from memory and persistent storage.
-    Most common use case for this method is user logout.
+    Most common use case for this method is customer logout.
 */
-public func logoutUser() {
-    AuthManager.sharedInstance.logoutUser()
+public func logoutCustomer() {
+    AuthManager.sharedInstance.logoutCustomer()
 }
 
 /**

--- a/Source/Commercetools.swift
+++ b/Source/Commercetools.swift
@@ -40,10 +40,11 @@ public var authState: AuthManager.TokenState {
 
     - parameter username:           The user's username.
     - parameter password:           The user's password.
+    - parameter activeCartSignInMode:   Optional sign in mode, specifying whether the cart line items should be merged.
     - parameter completionHandler:  The code to be executed once the token fetching completes.
 */
-public func login(username: String, password: String, completionHandler: @escaping (Error?) -> Void) {
-    AuthManager.sharedInstance.login(username: username, password: password, completionHandler: completionHandler)
+public func login(username: String, password: String, activeCartSignInMode: AnonymousCartSignInMode? = nil, completionHandler: @escaping (Error?) -> Void) {
+    AuthManager.sharedInstance.login(username: username, password: password, activeCartSignInMode: activeCartSignInMode, completionHandler: completionHandler)
 }
 
 /**

--- a/Source/Commercetools.swift
+++ b/Source/Commercetools.swift
@@ -42,7 +42,7 @@ public var authState: AuthManager.TokenState {
     - parameter password:           The user's password.
     - parameter completionHandler:  The code to be executed once the token fetching completes.
 */
-public func loginUser(_ username: String, password: String, completionHandler: @escaping (Error?) -> Void) {
+public func login(username: String, password: String, completionHandler: @escaping (Error?) -> Void) {
     AuthManager.sharedInstance.login(username: username, password: password, completionHandler: completionHandler)
 }
 

--- a/Source/Endpoints/Customer.swift
+++ b/Source/Endpoints/Customer.swift
@@ -35,8 +35,8 @@ open class Customer: Endpoint, Mappable {
         - parameter activeCartSignInMode:   Optional sign in mode, specifying whether the cart line items should be merged.
         - parameter completionHandler:      The code to be executed once the token fetching completes.
     */
-    open static func login(username: String, password: String, activeCartSignInMode: AnonymousCartSignInMode?,
-                           result: @escaping (Result<CustomerSignInResult>) -> Void) {
+    static func login(username: String, password: String, activeCartSignInMode: AnonymousCartSignInMode?,
+                      result: @escaping (Result<CustomerSignInResult>) -> Void) {
         var userDetails = ["email": username, "password": password]
         if let activeCartSignInMode = activeCartSignInMode {
             userDetails["activeCartSignInMode"] = activeCartSignInMode.rawValue
@@ -52,20 +52,10 @@ open class Customer: Endpoint, Mappable {
     /**
         Creates new customer with specified profile.
 
-        - parameter profile:                  Draft of the customer profile to be created.
-        - parameter result:                   The code to be executed after processing the response.
-    */
-    open static func signup(_ profile: CustomerDraft, result: @escaping (Result<CustomerSignInResult>) -> Void) {
-        signup(Mapper<CustomerDraft>().toJSON(profile), result: result)
-    }
-
-    /**
-        Creates new customer with specified profile.
-
         - parameter profile:                  Dictionary representation of the draft customer profile to be created.
         - parameter result:                   The code to be executed after processing the response.
     */
-    open static func signup(_ profile: [String: Any], result: @escaping (Result<CustomerSignInResult>) -> Void) {
+    open static func signUp(_ profile: [String: Any], result: @escaping (Result<CustomerSignInResult>) -> Void) {
         requestWithTokenAndPath(result, { token, path in
             Alamofire.request("\(path)signup", method: .post, parameters: profile, encoding: JSONEncoding.default, headers: self.headers(token))
                     .responseJSON(queue: DispatchQueue.global(), completionHandler: { response in
@@ -123,7 +113,7 @@ open class Customer: Endpoint, Mappable {
                               "newPassword": newPassword, "version": version], encoding: JSONEncoding.default, result: { changePasswordResult in
 
             if let response = changePasswordResult.json, let email = response["email"] as? String, changePasswordResult.isSuccess {
-                AuthManager.sharedInstance.login(username: email, password: newPassword, completionHandler: { error in
+                AuthManager.sharedInstance.loginCustomer(username: email, password: newPassword, completionHandler: { error in
                     if let error = error as? CTError {
                         Log.error("Could not login automatically after password change "
                                 + (error.errorDescription ?? ""))

--- a/Source/Endpoints/Customer.swift
+++ b/Source/Endpoints/Customer.swift
@@ -100,7 +100,7 @@ open class Customer: Endpoint, Mappable {
                               "newPassword": newPassword, "version": version], encoding: JSONEncoding.default, result: { changePasswordResult in
 
             if let response = changePasswordResult.json, let email = response["email"] as? String, changePasswordResult.isSuccess {
-                AuthManager.sharedInstance.loginUser(email, password: newPassword, completionHandler: { error in
+                AuthManager.sharedInstance.login(username: email, password: newPassword, completionHandler: { error in
                     if let error = error as? CTError {
                         Log.error("Could not login automatically after password change "
                                 + (error.errorDescription ?? ""))

--- a/Source/Models/AnonymousCartSignInMode.swift
+++ b/Source/Models/AnonymousCartSignInMode.swift
@@ -1,0 +1,12 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import Foundation
+
+public enum AnonymousCartSignInMode: String {
+
+    case mergeWithExistingCustomerCart = "MergeWithExistingCustomerCart"
+    case useAsNewActiveCustomerCart = "UseAsNewActiveCustomerCart"
+
+}

--- a/Tests/AuthManagerTests.swift
+++ b/Tests/AuthManagerTests.swift
@@ -32,7 +32,7 @@ class AuthManagerTests: XCTestCase {
         var oldToken: String?
         authManager.token { token, error in oldToken = token }
 
-        authManager.login(username: username, password: password, completionHandler: { error in
+        authManager.loginCustomer(username: username, password: password, completionHandler: { error in
             if error == nil {
                 loginExpectation.fulfill()
             }
@@ -57,13 +57,13 @@ class AuthManagerTests: XCTestCase {
         let password = "password"
         let authManager = AuthManager.sharedInstance
 
-        authManager.login(username: username, password: password, completionHandler: { error in
+        authManager.loginCustomer(username: username, password: password, completionHandler: { error in
             if error == nil {
                 // Get the access token after login
                 authManager.token { oldToken, error in
                     if let oldToken = oldToken, authManager.state == .customerToken {
                         // Then logout user
-                        authManager.logoutUser()
+                        authManager.logoutCustomer()
                         // Get the access token after logout
                         authManager.token { newToken, error in
                             if let newToken = newToken, newToken != oldToken && authManager.state == .anonymousToken {
@@ -91,7 +91,7 @@ class AuthManagerTests: XCTestCase {
         var oldToken: String?
         authManager.token { token, error in oldToken = token }
 
-        authManager.login(username: username, password: password, completionHandler: { error in
+        authManager.loginCustomer(username: username, password: password, completionHandler: { error in
             if let error = error as? CTError, case .accessTokenRetrievalFailed(let reason) = error, reason.message == "invalid_customer_account_credentials" &&
                     reason.details == "Customer account with the given credentials not found." {
                 loginExpectation.fulfill()
@@ -136,7 +136,7 @@ class AuthManagerTests: XCTestCase {
         let username = "swift.sdk.test.user@commercetools.com"
         let password = "password"
 
-        authManager.login(username: username, password: password, completionHandler: { error in
+        authManager.loginCustomer(username: username, password: password, completionHandler: { error in
             if error == nil {
 
                 var oldToken: String?
@@ -248,9 +248,9 @@ class AuthManagerTests: XCTestCase {
                 let username = "swift.sdk.test.user8@commercetools.com"
                 let password = "password"
 
-                authManager.login(username: username, password: password, activeCartSignInMode: .mergeWithExistingCustomerCart,
-                        completionHandler: { error in
-                    if error == nil {
+                Commercetools.loginCustomer(username: username, password: password,
+                        activeCartSignInMode: .mergeWithExistingCustomerCart, result: { result in
+                    if result.isSuccess {
                         authManager.token { token, error in
                             if authManager.state == .customerToken {
                                 Cart.active(result: { result in
@@ -289,30 +289,28 @@ class AuthManagerTests: XCTestCase {
         Cart.create(cartDraft, result: { result in
             if let oldCart = result.model, oldCart.cartState == .active && result.isSuccess {
 
-                Customer.signup(customerDraft, result: { result in
+                Commercetools.signUpCustomer(customerDraft, result: { result in
                     if let customerVersion = result.model?.customer?.version, result.isSuccess {
-                        authManager.login(username: username, password: "password", completionHandler: { error in
-                            if error == nil {
-                                authManager.token { token, error in
-                                    if authManager.state == .customerToken {
-                                        Cart.active(result: { result in
-                                            if let migratedCart = result.model, migratedCart.id == oldCart.id && result.isSuccess {
-                                                Customer.delete(version: customerVersion, result: { result in
-                                                    if result.isSuccess {
-                                                        cartMigrationExpectation.fulfill()
-                                                    }
-                                                })
-                                            }
-                                        })
-                                    }
+                        if result.isSuccess {
+                            authManager.token { token, error in
+                                if authManager.state == .customerToken {
+                                    Cart.active(result: { result in
+                                        if let migratedCart = result.model, migratedCart.id == oldCart.id && result.isSuccess {
+                                            Customer.delete(version: customerVersion, result: { result in
+                                                if result.isSuccess {
+                                                    cartMigrationExpectation.fulfill()
+                                                }
+                                            })
+                                        }
+                                    })
                                 }
                             }
-                        })
+                        }
                     }
                 })
             }
         })
 
-        waitForExpectations(timeout: 10, handler: nil)
+        waitForExpectations(timeout: 1000, handler: nil)
     }
 }

--- a/Tests/AuthManagerTests.swift
+++ b/Tests/AuthManagerTests.swift
@@ -32,7 +32,7 @@ class AuthManagerTests: XCTestCase {
         var oldToken: String?
         authManager.token { token, error in oldToken = token }
 
-        authManager.loginUser(username, password: password, completionHandler: { error in
+        authManager.login(username: username, password: password, completionHandler: { error in
             if error == nil {
                 loginExpectation.fulfill()
             }
@@ -57,7 +57,7 @@ class AuthManagerTests: XCTestCase {
         let password = "password"
         let authManager = AuthManager.sharedInstance
 
-        authManager.loginUser(username, password: password, completionHandler: { error in
+        authManager.login(username: username, password: password, completionHandler: { error in
             if error == nil {
                 // Get the access token after login
                 authManager.token { oldToken, error in
@@ -91,7 +91,7 @@ class AuthManagerTests: XCTestCase {
         var oldToken: String?
         authManager.token { token, error in oldToken = token }
 
-        authManager.loginUser(username, password: password, completionHandler: { error in
+        authManager.login(username: username, password: password, completionHandler: { error in
             if let error = error as? CTError, case .accessTokenRetrievalFailed(let reason) = error, reason.message == "invalid_customer_account_credentials" &&
                     reason.details == "Customer account with the given credentials not found." {
                 loginExpectation.fulfill()
@@ -136,7 +136,7 @@ class AuthManagerTests: XCTestCase {
         let username = "swift.sdk.test.user@commercetools.com"
         let password = "password"
 
-        authManager.loginUser(username, password: password, completionHandler: { error in
+        authManager.login(username: username, password: password, completionHandler: { error in
             if error == nil {
 
                 var oldToken: String?

--- a/Tests/Core/ByIdEndpointTests.swift
+++ b/Tests/Core/ByIdEndpointTests.swift
@@ -36,7 +36,7 @@ class ByIdEndpointTests: XCTestCase {
         let username = "swift.sdk.test.user2@commercetools.com"
         let password = "password"
         
-        AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
+        AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
         
         TestCart.create(["currency": "EUR"], result: { result in
             if let response = result.json, let id = response["id"] as? String, result.isSuccess {
@@ -59,7 +59,7 @@ class ByIdEndpointTests: XCTestCase {
         let username = "swift.sdk.test.user2@commercetools.com"
         let password = "password"
 
-        AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
+        AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
 
         TestCart.byId("cddddddd-ffff-4b44-b5b0-004e7d4bc2dd", result: { result in
             if let error = result.errors?.first as? CTError, result.statusCode == 404, case .resourceNotFoundError(let reason) = error,

--- a/Tests/Core/ByIdEndpointTests.swift
+++ b/Tests/Core/ByIdEndpointTests.swift
@@ -36,7 +36,7 @@ class ByIdEndpointTests: XCTestCase {
         let username = "swift.sdk.test.user2@commercetools.com"
         let password = "password"
         
-        AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
+        AuthManager.sharedInstance.loginCustomer(username: username, password: password, completionHandler: { _ in})
         
         TestCart.create(["currency": "EUR"], result: { result in
             if let response = result.json, let id = response["id"] as? String, result.isSuccess {
@@ -59,7 +59,7 @@ class ByIdEndpointTests: XCTestCase {
         let username = "swift.sdk.test.user2@commercetools.com"
         let password = "password"
 
-        AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
+        AuthManager.sharedInstance.loginCustomer(username: username, password: password, completionHandler: { _ in})
 
         TestCart.byId("cddddddd-ffff-4b44-b5b0-004e7d4bc2dd", result: { result in
             if let error = result.errors?.first as? CTError, result.statusCode == 404, case .resourceNotFoundError(let reason) = error,

--- a/Tests/Core/CreateEndpointTests.swift
+++ b/Tests/Core/CreateEndpointTests.swift
@@ -31,7 +31,7 @@ class CreateEndpointTests: XCTestCase {
         let username = "swift.sdk.test.user2@commercetools.com"
         let password = "password"
 
-        AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
+        AuthManager.sharedInstance.loginCustomer(username: username, password: password, completionHandler: { _ in})
 
         TestCart.create(["currency": "EUR"], result: { result in
             if let response = result.json, let cartState = response["cartState"] as? String, let version = response["version"] as? Int,
@@ -50,7 +50,7 @@ class CreateEndpointTests: XCTestCase {
         let username = "swift.sdk.test.user2@commercetools.com"
         let password = "password"
 
-        AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
+        AuthManager.sharedInstance.loginCustomer(username: username, password: password, completionHandler: { _ in})
 
         TestCart.create(["currency": "BAD"], result: { result in
             if let error = result.errors?.first as? CTError, result.statusCode == 400, case .invalidJsonInputError(let reason) = error,

--- a/Tests/Core/CreateEndpointTests.swift
+++ b/Tests/Core/CreateEndpointTests.swift
@@ -31,7 +31,7 @@ class CreateEndpointTests: XCTestCase {
         let username = "swift.sdk.test.user2@commercetools.com"
         let password = "password"
 
-        AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
+        AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
 
         TestCart.create(["currency": "EUR"], result: { result in
             if let response = result.json, let cartState = response["cartState"] as? String, let version = response["version"] as? Int,
@@ -50,7 +50,7 @@ class CreateEndpointTests: XCTestCase {
         let username = "swift.sdk.test.user2@commercetools.com"
         let password = "password"
 
-        AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
+        AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
 
         TestCart.create(["currency": "BAD"], result: { result in
             if let error = result.errors?.first as? CTError, result.statusCode == 400, case .invalidJsonInputError(let reason) = error,

--- a/Tests/Core/DeleteEndpointTests.swift
+++ b/Tests/Core/DeleteEndpointTests.swift
@@ -31,7 +31,7 @@ class DeleteEndpointTests: XCTestCase {
         let username = "swift.sdk.test.user2@commercetools.com"
         let password = "password"
 
-        AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
+        AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
 
         TestCart.create(["currency": "EUR"], result: { result in
             if let response = result.json, let id = response["id"] as? String, let version = response["version"] as? UInt, result.isSuccess {
@@ -54,7 +54,7 @@ class DeleteEndpointTests: XCTestCase {
         let username = "swift.sdk.test.user2@commercetools.com"
         let password = "password"
 
-        AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
+        AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
 
         TestCart.create(["currency": "EUR"], result: { result in
             if let response = result.json, let id = response["id"] as? String, let version = response["version"] as? UInt, result.isSuccess {
@@ -77,7 +77,7 @@ class DeleteEndpointTests: XCTestCase {
         let username = "swift.sdk.test.user2@commercetools.com"
         let password = "password"
 
-        AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
+        AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
 
         TestCart.delete("cddddddd-ffff-4b44-b5b0-004e7d4bc2dd", version: 1, result: { result in
             if let error = result.errors?.first as? CTError, result.statusCode == 404, case .resourceNotFoundError(let reason) = error,

--- a/Tests/Core/DeleteEndpointTests.swift
+++ b/Tests/Core/DeleteEndpointTests.swift
@@ -31,7 +31,7 @@ class DeleteEndpointTests: XCTestCase {
         let username = "swift.sdk.test.user2@commercetools.com"
         let password = "password"
 
-        AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
+        AuthManager.sharedInstance.loginCustomer(username: username, password: password, completionHandler: { _ in})
 
         TestCart.create(["currency": "EUR"], result: { result in
             if let response = result.json, let id = response["id"] as? String, let version = response["version"] as? UInt, result.isSuccess {
@@ -54,7 +54,7 @@ class DeleteEndpointTests: XCTestCase {
         let username = "swift.sdk.test.user2@commercetools.com"
         let password = "password"
 
-        AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
+        AuthManager.sharedInstance.loginCustomer(username: username, password: password, completionHandler: { _ in})
 
         TestCart.create(["currency": "EUR"], result: { result in
             if let response = result.json, let id = response["id"] as? String, let version = response["version"] as? UInt, result.isSuccess {
@@ -77,7 +77,7 @@ class DeleteEndpointTests: XCTestCase {
         let username = "swift.sdk.test.user2@commercetools.com"
         let password = "password"
 
-        AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
+        AuthManager.sharedInstance.loginCustomer(username: username, password: password, completionHandler: { _ in})
 
         TestCart.delete("cddddddd-ffff-4b44-b5b0-004e7d4bc2dd", version: 1, result: { result in
             if let error = result.errors?.first as? CTError, result.statusCode == 404, case .resourceNotFoundError(let reason) = error,

--- a/Tests/Core/UpdateEndpointTests.swift
+++ b/Tests/Core/UpdateEndpointTests.swift
@@ -37,7 +37,7 @@ class UpdateEndpointTests: XCTestCase {
         let username = "swift.sdk.test.user2@commercetools.com"
         let password = "password"
 
-        AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
+        AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
 
         TestProductProjections.query(limit: 1, result: { result in
             if let response = result.json, let results = response["results"] as? [[String: AnyObject]],
@@ -69,7 +69,7 @@ class UpdateEndpointTests: XCTestCase {
         let username = "swift.sdk.test.user2@commercetools.com"
         let password = "password"
 
-        AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
+        AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
 
         TestProductProjections.query(limit: 1, result: { result in
             if let response = result.json, let results = response["results"] as? [[String: AnyObject]],
@@ -101,7 +101,7 @@ class UpdateEndpointTests: XCTestCase {
         let username = "swift.sdk.test.user2@commercetools.com"
         let password = "password"
 
-        AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
+        AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
 
         TestCart.update("cddddddd-ffff-4b44-b5b0-004e7d4bc2dd", version: 1, actions: [], result: { result in
             if let error = result.errors?.first as? CTError, result.statusCode == 404, case .resourceNotFoundError(let reason) = error,

--- a/Tests/Core/UpdateEndpointTests.swift
+++ b/Tests/Core/UpdateEndpointTests.swift
@@ -37,7 +37,7 @@ class UpdateEndpointTests: XCTestCase {
         let username = "swift.sdk.test.user2@commercetools.com"
         let password = "password"
 
-        AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
+        AuthManager.sharedInstance.loginCustomer(username: username, password: password, completionHandler: { _ in})
 
         TestProductProjections.query(limit: 1, result: { result in
             if let response = result.json, let results = response["results"] as? [[String: AnyObject]],
@@ -69,7 +69,7 @@ class UpdateEndpointTests: XCTestCase {
         let username = "swift.sdk.test.user2@commercetools.com"
         let password = "password"
 
-        AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
+        AuthManager.sharedInstance.loginCustomer(username: username, password: password, completionHandler: { _ in})
 
         TestProductProjections.query(limit: 1, result: { result in
             if let response = result.json, let results = response["results"] as? [[String: AnyObject]],
@@ -101,7 +101,7 @@ class UpdateEndpointTests: XCTestCase {
         let username = "swift.sdk.test.user2@commercetools.com"
         let password = "password"
 
-        AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
+        AuthManager.sharedInstance.loginCustomer(username: username, password: password, completionHandler: { _ in})
 
         TestCart.update("cddddddd-ffff-4b44-b5b0-004e7d4bc2dd", version: 1, actions: [], result: { result in
             if let error = result.errors?.first as? CTError, result.statusCode == 404, case .resourceNotFoundError(let reason) = error,

--- a/Tests/Endpoints/CartTests.swift
+++ b/Tests/Endpoints/CartTests.swift
@@ -24,7 +24,7 @@ class CartTests: XCTestCase {
         let username = "swift.sdk.test.user2@commercetools.com"
         let password = "password"
 
-        AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
+        AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
 
         Cart.create(["currency": "EUR"], result: { result in
             if let response = result.json, let cartState = response["cartState"] as? String, let id = response["id"] as? String,
@@ -46,7 +46,7 @@ class CartTests: XCTestCase {
         let username = "swift.sdk.test.user2@commercetools.com"
         let password = "password"
 
-        AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
+        AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
 
         retrieveSampleProduct { lineItemDraft in
             var cartDraft = CartDraft()
@@ -69,7 +69,7 @@ class CartTests: XCTestCase {
         let username = "swift.sdk.test.user2@commercetools.com"
         let password = "password"
 
-        AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
+        AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
 
         retrieveSampleProduct { lineItemDraft in
             var cartDraft = CartDraft()
@@ -103,7 +103,7 @@ class CartTests: XCTestCase {
         let username = "swift.sdk.test.user2@commercetools.com"
         let password = "password"
 
-        AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
+        AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
 
         var cartDraft = CartDraft()
         cartDraft.currency = "EUR"

--- a/Tests/Endpoints/CartTests.swift
+++ b/Tests/Endpoints/CartTests.swift
@@ -24,7 +24,7 @@ class CartTests: XCTestCase {
         let username = "swift.sdk.test.user2@commercetools.com"
         let password = "password"
 
-        AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
+        AuthManager.sharedInstance.loginCustomer(username: username, password: password, completionHandler: { _ in})
 
         Cart.create(["currency": "EUR"], result: { result in
             if let response = result.json, let cartState = response["cartState"] as? String, let id = response["id"] as? String,
@@ -46,7 +46,7 @@ class CartTests: XCTestCase {
         let username = "swift.sdk.test.user2@commercetools.com"
         let password = "password"
 
-        AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
+        AuthManager.sharedInstance.loginCustomer(username: username, password: password, completionHandler: { _ in})
 
         retrieveSampleProduct { lineItemDraft in
             var cartDraft = CartDraft()
@@ -69,7 +69,7 @@ class CartTests: XCTestCase {
         let username = "swift.sdk.test.user2@commercetools.com"
         let password = "password"
 
-        AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
+        AuthManager.sharedInstance.loginCustomer(username: username, password: password, completionHandler: { _ in})
 
         retrieveSampleProduct { lineItemDraft in
             var cartDraft = CartDraft()
@@ -103,7 +103,7 @@ class CartTests: XCTestCase {
         let username = "swift.sdk.test.user2@commercetools.com"
         let password = "password"
 
-        AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
+        AuthManager.sharedInstance.loginCustomer(username: username, password: password, completionHandler: { _ in})
 
         var cartDraft = CartDraft()
         cartDraft.currency = "EUR"

--- a/Tests/Endpoints/CustomerTests.swift
+++ b/Tests/Endpoints/CustomerTests.swift
@@ -102,12 +102,13 @@ class CustomerTests: XCTestCase {
             if let customer = result.model?.customer, let version = customer.version, customer.email == username, result.isSuccess {
                 createProfileExpectation.fulfill()
 
-                AuthManager.sharedInstance.login(username: username, password: "password", completionHandler: { _ in})
-                Customer.delete(version: version, result: { result in
-                    if let deletedCustomer = result.model, deletedCustomer.email == username, result.isSuccess {
-                        deleteProfileExpectation.fulfill()
-                    }
-                })
+                AuthManager.sharedInstance.login(username: username, password: "password") { _ in
+                    Customer.delete(version: version, result: { result in
+                        if let deletedCustomer = result.model, deletedCustomer.email == username, result.isSuccess {
+                            deleteProfileExpectation.fulfill()
+                        }
+                    })
+                }
             }
         })
 

--- a/Tests/Endpoints/CustomerTests.swift
+++ b/Tests/Endpoints/CustomerTests.swift
@@ -30,7 +30,7 @@ class CustomerTests: XCTestCase {
         let username = "swift.sdk.test.user2@commercetools.com"
         let password = "password"
 
-        AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
+        AuthManager.sharedInstance.loginCustomer(username: username, password: password, completionHandler: { _ in})
 
         Customer.profile { result in
             if let response = result.json, let _ = response["firstName"] as? String,
@@ -67,13 +67,13 @@ class CustomerTests: XCTestCase {
 
         let signupDraft = ["email": username, "password": "password"]
 
-        Customer.signup(signupDraft, result: { result in
+        Customer.signUp(signupDraft, result: { result in
             if let response = result.json, let customer = response["customer"] as? [String: Any],
                     let email = customer["email"] as? String, let version = customer["version"] as? UInt, result.isSuccess
                     && email == username {
                 createProfileExpectation.fulfill()
 
-                AuthManager.sharedInstance.login(username: username, password: "password", completionHandler: { _ in})
+                AuthManager.sharedInstance.loginCustomer(username: username, password: "password", completionHandler: { _ in})
                 Customer.delete(version: version, result: { result in
                     if let response = result.json, let email = response["email"] as? String, result.isSuccess
                             && email == username {
@@ -98,11 +98,11 @@ class CustomerTests: XCTestCase {
         customerDraft.email = username
         customerDraft.password = "password"
 
-        Customer.signup(customerDraft, result: { result in
+        Commercetools.signUpCustomer(customerDraft, result: { result in
             if let customer = result.model?.customer, let version = customer.version, customer.email == username, result.isSuccess {
                 createProfileExpectation.fulfill()
 
-                AuthManager.sharedInstance.login(username: username, password: "password") { _ in
+                AuthManager.sharedInstance.loginCustomer(username: username, password: "password") { _ in
                     Customer.delete(version: version, result: { result in
                         if let deletedCustomer = result.model, deletedCustomer.email == username, result.isSuccess {
                             deleteProfileExpectation.fulfill()
@@ -123,7 +123,7 @@ class CustomerTests: XCTestCase {
         let username = "swift.sdk.test.user2@commercetools.com"
         let password = "password"
 
-        AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
+        AuthManager.sharedInstance.loginCustomer(username: username, password: password, completionHandler: { _ in})
 
         Customer.profile { result in
             if let profile = result.model, let version = profile.version, result.isSuccess {
@@ -157,7 +157,7 @@ class CustomerTests: XCTestCase {
 
         let signupDraft = ["email": "swift.sdk.test.user2@commercetools.com", "password": "password"]
 
-        Customer.signup(signupDraft, result: { result in
+        Customer.signUp(signupDraft, result: { result in
             if let error = result.errors?.first as? CTError, case .generalError(let reason) = error,
                     reason?.message == "There is already an existing customer with the email '\"swift.sdk.test.user2@commercetools.com\"'." {
                 createProfileExpectation.fulfill()
@@ -190,7 +190,7 @@ class CustomerTests: XCTestCase {
         let username = "swift.sdk.test.user2@commercetools.com"
         let password = "password"
 
-        AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
+        AuthManager.sharedInstance.loginCustomer(username: username, password: password, completionHandler: { _ in})
 
         var setFirstNameAction: [String: Any] = ["action": "setFirstName", "firstName": "newName"]
 
@@ -242,7 +242,7 @@ class CustomerTests: XCTestCase {
         let username = "swift.sdk.test.user2@commercetools.com"
         let password = "password"
 
-        AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
+        AuthManager.sharedInstance.loginCustomer(username: username, password: password, completionHandler: { _ in})
 
         Customer.profile { result in
             if let response = result.json, let version = response["version"] as? UInt, result.isSuccess {
@@ -327,7 +327,7 @@ class CustomerTests: XCTestCase {
                             
                             // Confirm email verification token with regular mobile client scope
                             self.setupTestConfiguration()
-                            AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
+                            AuthManager.sharedInstance.loginCustomer(username: username, password: password, completionHandler: { _ in})
                             
                             Customer.verifyEmail(token: token, result: { result in
                                 if let response = result.json, let email = response["email"] as? String, result.isSuccess

--- a/Tests/Endpoints/CustomerTests.swift
+++ b/Tests/Endpoints/CustomerTests.swift
@@ -30,7 +30,7 @@ class CustomerTests: XCTestCase {
         let username = "swift.sdk.test.user2@commercetools.com"
         let password = "password"
 
-        AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
+        AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
 
         Customer.profile { result in
             if let response = result.json, let _ = response["firstName"] as? String,
@@ -73,7 +73,7 @@ class CustomerTests: XCTestCase {
                     && email == username {
                 createProfileExpectation.fulfill()
 
-                AuthManager.sharedInstance.loginUser(username, password: "password", completionHandler: {_ in})
+                AuthManager.sharedInstance.login(username: username, password: "password", completionHandler: { _ in})
                 Customer.delete(version: version, result: { result in
                     if let response = result.json, let email = response["email"] as? String, result.isSuccess
                             && email == username {
@@ -102,7 +102,7 @@ class CustomerTests: XCTestCase {
             if let customer = result.model?.customer, let version = customer.version, customer.email == username, result.isSuccess {
                 createProfileExpectation.fulfill()
 
-                AuthManager.sharedInstance.loginUser(username, password: "password", completionHandler: {_ in})
+                AuthManager.sharedInstance.login(username: username, password: "password", completionHandler: { _ in})
                 Customer.delete(version: version, result: { result in
                     if let deletedCustomer = result.model, deletedCustomer.email == username, result.isSuccess {
                         deleteProfileExpectation.fulfill()
@@ -122,7 +122,7 @@ class CustomerTests: XCTestCase {
         let username = "swift.sdk.test.user2@commercetools.com"
         let password = "password"
 
-        AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
+        AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
 
         Customer.profile { result in
             if let profile = result.model, let version = profile.version, result.isSuccess {
@@ -189,7 +189,7 @@ class CustomerTests: XCTestCase {
         let username = "swift.sdk.test.user2@commercetools.com"
         let password = "password"
 
-        AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
+        AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
 
         var setFirstNameAction: [String: Any] = ["action": "setFirstName", "firstName": "newName"]
 
@@ -241,7 +241,7 @@ class CustomerTests: XCTestCase {
         let username = "swift.sdk.test.user2@commercetools.com"
         let password = "password"
 
-        AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
+        AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
 
         Customer.profile { result in
             if let response = result.json, let version = response["version"] as? UInt, result.isSuccess {
@@ -326,7 +326,7 @@ class CustomerTests: XCTestCase {
                             
                             // Confirm email verification token with regular mobile client scope
                             self.setupTestConfiguration()
-                            AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
+                            AuthManager.sharedInstance.login(username: username, password: password, completionHandler: { _ in})
                             
                             Customer.verifyEmail(token: token, result: { result in
                                 if let response = result.json, let email = response["email"] as? String, result.isSuccess


### PR DESCRIPTION
What we've done in this issue:
- Added `activeCartSignInMode: AnonymousCartSignInMode?` to the `AuthManager`'s `login` method;
- Added `login` method to the `Customer` endpoint, which can be explicitly used by the user in order to invoke carts and orders migration from the anonymous user (this happens automatically on the API side for sign up);
- Since the API doesn't automatically migrate carts and orders when there's no sign up, just login, we're doing that in the SDK. From the users perspective, it's enough to invoke `AuthManager`'s `login` method, and we'll perform `me/login` request, and obtain access and refresh token afterwards.
- Added tests which cover cart migration for logging in the existing user, and another to cover migration for new user (on sign up).
