### PR TITLE
Closes #89 Add config option for keychain sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ The Commercetools SDK uses a `.plist` configuration file named `CommercetoolsCon
 	<string>https://api.sphere.io</string>
 	<key>anonymousSession</key>
     <true/>
+    <key>keychainAccessGroupName</key>
+    <string>AB123CDEF.yourKeychainGroup</string>
     <key>emergencyContactInfo</key>
     <string>you@yourdomain.com</string>
 </dict>
@@ -125,7 +127,10 @@ Commercetools.obtainAnonymousToken(usingSession: true, anonymousId: "some-custom
     }
 })
 ```
-When an anonymous sessions ends with a sign up or a login, carts and orders are migrated to the customer, and `CustomerSignInResult` is returned, providing access to both customer profile, and the currently active cart. For the login operation, you can define how to migrate line items from the currently active cart, by explicitly specifying one of two `AnonymousCartSignInMode` values: `.mergeWithExistingCustomerCart` or `.useAsNewActiveCustomerCart`. 
+When an anonymous sessions ends with a sign up or a login, carts and orders are migrated to the customer, and `CustomerSignInResult` is returned, providing access to both customer profile, and the currently active cart. For the login operation, you can define how to migrate line items from the currently active cart, by explicitly specifying one of two `AnonymousCartSignInMode` values: `.mergeWithExistingCustomerCart` or `.useAsNewActiveCustomerCart`.
+
+If your app has extensions, and you want to use Commercetools SDK in those extensions, we recommend enabling keychain sharing. By allowing keychain sharing, and setting the appropriate access group name in the configuration `.plist`, the SDK will save all tokens in the shared keychain. Be sure to include _App ID Prefix / Team ID_ in the access group name.
+As a result, you can use all endpoints with the same authorization state and tokens in both your app and any extension. The same goes for multiple apps from your development team using keychain sharing. 
 
 ## Consuming Commercetools Endpoints
 

--- a/Source/AuthManager.swift
+++ b/Source/AuthManager.swift
@@ -117,7 +117,7 @@ open class AuthManager {
     }
 
     /// The serial queue used for processing token requests.
-    private let serialQueue = DispatchQueue(label: "com.commercetools.authQueue", attributes: []);
+    private let serialQueue = DispatchQueue(label: "com.commercetools.authQueue");
 
     // MARK: - Lifecycle
 

--- a/Source/Config.swift
+++ b/Source/Config.swift
@@ -43,6 +43,9 @@ public class Config {
     /// Configuration parameter determining whether the SDK should obtain anonymous session token or plain token.
     public private(set) var anonymousSession: Bool
 
+    /// Keychain access group name the SDK will use for apps and extensions with enabled keychain sharing.
+    public private(set) var keychainAccessGroupName: String?
+
     /// Emergency contact info which is passed to the platform.
     public private(set) var emergencyContactInfo: String?
 
@@ -122,6 +125,7 @@ public class Config {
         authUrl = config["authUrl"] as? String
         apiUrl = config["apiUrl"] as? String
         anonymousSession = config["anonymousSession"] as? Bool ?? false
+        keychainAccessGroupName = config["keychainAccessGroupName"] as? String
         emergencyContactInfo = config["emergencyContactInfo"] as? String
 
         if let apiUrl = apiUrl, !apiUrl.hasSuffix("/") {


### PR DESCRIPTION
In situations where the app using Commercetools SDK has extensions (such as today extension, notification content extension, etc), we want to enable our users to seamlessly use endpoints from the SDK in those extensions with the same auth tokens.

Common use cases:
- An app has a rich notification, which needs to retrieve an object from our API in order to display the rich content;
- An app has a today widget, which would like to show an overview of reservations ready for pickup, etc;

In any of those cases, the user has previously logged in using the app, but since the app and the extension run in a different sandbox, the extension wouldn't be able to get the data needed from the API, because it doesn't contain proper auth tokens.

The solution for this problem is to allow SDK users to setup keychain sharing and specify _keychain group_ in the SDK plist config. As a result, the SDK won't store the tokens in the default location, but in the shared keychain, making it accessible by both the app and the extension.