### PR TITLE
Closes #102 UserAgent headers for newly added platforms

### DIFF
--- a/Source/Core/Endpoint.swift
+++ b/Source/Core/Endpoint.swift
@@ -61,11 +61,17 @@ public extension Endpoint {
             let version = ProcessInfo.processInfo.operatingSystemVersion
 
             let osName: String = {
-            #if os(iOS)
-                return "iOS"
-            #else
-                return "Unknown"
-            #endif
+                #if os(iOS)
+                    return "iOS"
+                #elseif os(watchOS)
+                    return "watchOS"
+                #elseif os(tvOS)
+                    return "tvOS"
+                #elseif os(macOS)
+                    return "macOS"
+                #else
+                    return "Unknown"
+                #endif
             }()
 
             return "\(osName)/\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"


### PR DESCRIPTION
Just a minor update to the UserAgent method  - now we will be able to see the actual platform / OS that is using the Swift SDK to communicate with the commercetools platform.