### PR TITLE
Closes #114 Add taxRoundingMode field to Cart and CartDraft

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,5 +8,6 @@ let package = Package(
 name: "Commercetools",
         dependencies: [
                 .Package(url: "https://github.com/Alamofire/Alamofire.git", majorVersion: 4),
+                .Package(url: "https://github.com/Hearst-DD/ObjectMapper.git", majorVersion: 2),
         ]
 )

--- a/Source/Endpoints/Cart.swift
+++ b/Source/Endpoints/Cart.swift
@@ -45,6 +45,7 @@ open class Cart: QueryEndpoint, ByIdEndpoint, CreateEndpoint, UpdateEndpoint, De
     public var billingAddress: Address?
     public var inventoryMode: InventoryMode?
     public var taxMode: TaxMode?
+    public var taxRoundingMode: RoundingMode?
     public var customerGroup: Reference<CustomerGroup>?
     public var country: String?
     public var shippingInfo: ShippingInfo?
@@ -74,6 +75,7 @@ open class Cart: QueryEndpoint, ByIdEndpoint, CreateEndpoint, UpdateEndpoint, De
         billingAddress   <- map["billingAddress"]
         inventoryMode    <- map["inventoryMode"]
         taxMode          <- map["taxMode"]
+        taxRoundingMode  <- map["taxRoundingMode"]
         customerGroup    <- map["customerGroup"]
         country          <- map["country"]
         shippingInfo     <- map["shippingInfo"]

--- a/Source/Models/Models.swift
+++ b/Source/Models/Models.swift
@@ -292,6 +292,7 @@ public struct CartDraft: Mappable {
     public var country: String?
     public var inventoryMode: InventoryMode?
     public var taxMode: TaxMode?
+    public var taxRoundingMode: RoundingMode?
     public var lineItems: [LineItemDraft]?
     public var customLineItems: [CustomLineItemDraft]?
     public var shippingAddress: Address?
@@ -314,6 +315,7 @@ public struct CartDraft: Mappable {
         country                           <- map["country"]
         inventoryMode                     <- map["inventoryMode"]
         taxMode                           <- map["taxMode"]
+        taxRoundingMode                   <- map["taxRoundingMode"]
         lineItems                         <- map["lineItems"]
         customLineItems                   <- map["customLineItems"]
         shippingAddress                   <- map["shippingAddress"]
@@ -2450,6 +2452,14 @@ public enum TaxMode: String {
     case platform = "Platform"
     case external = "External"
     case disabled = "Disabled"
+
+}
+
+public enum RoundingMode: String {
+
+    case halfEven = "HalfEven"
+    case halfUp = "HalfUp"
+    case halfDown = "HalfDown"
 
 }
 

--- a/Source/Models/Models.swift
+++ b/Source/Models/Models.swift
@@ -356,6 +356,7 @@ public enum CartUpdateAction: JSONRepresentable {
     case setLineItemCustomField(options: SetLineItemCustomFieldOptions)
     case addPayment(options: AddPaymentOptions)
     case removePayment(options: RemovePaymentOptions)
+    case changeTaxMode(options: ChangeTaxModeOptions)
     case setLocale(options: SetLocaleOptions)
 
     public var toJSON: [String: Any] {
@@ -431,6 +432,10 @@ public enum CartUpdateAction: JSONRepresentable {
         case .removePayment(let options):
             var optionsJSON = toJSON(options)
             optionsJSON["action"] = "removePayment"
+            return optionsJSON
+        case .changeTaxMode(let options):
+            var optionsJSON = toJSON(options)
+            optionsJSON["action"] = "changeTaxMode"
             return optionsJSON
         case .setLocale(let options):
             var optionsJSON = toJSON(options)
@@ -759,6 +764,22 @@ public struct RemovePaymentOptions: Mappable {
 
     mutating public func mapping(map: Map) {
         payment                     <- map["payment"]
+    }
+}
+
+public struct ChangeTaxModeOptions: Mappable {
+
+    // MARK: - Properties
+
+    public var taxMode: TaxMode?
+
+    public init() {}
+    public init?(map: Map) {}
+
+    // MARK: - Mappable
+
+    mutating public func mapping(map: Map) {
+        taxMode                     <- map["taxMode"]
     }
 }
 

--- a/Source/Models/Models.swift
+++ b/Source/Models/Models.swift
@@ -292,7 +292,6 @@ public struct CartDraft: Mappable {
     public var country: String?
     public var inventoryMode: InventoryMode?
     public var taxMode: TaxMode?
-    public var taxRoundingMode: RoundingMode?
     public var lineItems: [LineItemDraft]?
     public var customLineItems: [CustomLineItemDraft]?
     public var shippingAddress: Address?
@@ -315,7 +314,6 @@ public struct CartDraft: Mappable {
         country                           <- map["country"]
         inventoryMode                     <- map["inventoryMode"]
         taxMode                           <- map["taxMode"]
-        taxRoundingMode                   <- map["taxRoundingMode"]
         lineItems                         <- map["lineItems"]
         customLineItems                   <- map["customLineItems"]
         shippingAddress                   <- map["shippingAddress"]


### PR DESCRIPTION
Even though we don't have `taxRoundingMode` documented in the [MyCartDraft](http://dev.commercetools.com/http-api-projects-me-carts.html#mycartdraft), specifying the rounding mode when using `me/carts` endpoint works properly.
However, the `changeTaxRoundingMode` update action does not work.