### PR TITLE
Closes #126 Add ShippingMethod endpoint support

### DIFF
--- a/Commercetools.xcodeproj/project.pbxproj
+++ b/Commercetools.xcodeproj/project.pbxproj
@@ -125,6 +125,7 @@
 		21C6534D1CBE6292008E84B2 /* Commercetools.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 21C653421CBE6291008E84B2 /* Commercetools.framework */; };
 		21C653521CBE6292008E84B2 /* AuthManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C653511CBE6292008E84B2 /* AuthManagerTests.swift */; };
 		21D462041D23FD0A00CB8C8E /* CartTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D462031D23FD0A00CB8C8E /* CartTests.swift */; };
+		21DE0C741E70C74E00644A16 /* ShippingMethodTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DE0C731E70C74E00644A16 /* ShippingMethodTests.swift */; };
 		21F26D8F1CD0B8B100DFFEB8 /* XCTestCase+Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F26D8E1CD0B8B100DFFEB8 /* XCTestCase+Configuration.swift */; };
 		2699468A8EDDC145F9E519BD /* Pods_Commercetools_watchOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D0D1C0DE43563BABA0F6967 /* Pods_Commercetools_watchOS.framework */; };
 		414995925A8A1BA2A088EC04 /* Pods_Commercetools_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9E9FFCA28231E62ECBEFB099 /* Pods_Commercetools_tvOS.framework */; };
@@ -193,6 +194,7 @@
 		21C6534C1CBE6292008E84B2 /* Commercetools iOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Commercetools iOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		21C653511CBE6292008E84B2 /* AuthManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManagerTests.swift; sourceTree = "<group>"; };
 		21D462031D23FD0A00CB8C8E /* CartTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CartTests.swift; sourceTree = "<group>"; };
+		21DE0C731E70C74E00644A16 /* ShippingMethodTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShippingMethodTests.swift; sourceTree = "<group>"; };
 		21F26D8E1CD0B8B100DFFEB8 /* XCTestCase+Configuration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Configuration.swift"; sourceTree = "<group>"; };
 		256A6E381D558468047FB1AB /* Pods-Commercetools tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Commercetools tvOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Commercetools tvOS/Pods-Commercetools tvOS.debug.xcconfig"; sourceTree = "<group>"; };
 		29502A041BA37E6BD22C3C21 /* Pods-Commercetools.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Commercetools.release.xcconfig"; path = "Pods/Target Support Files/Pods-Commercetools/Pods-Commercetools.release.xcconfig"; sourceTree = "<group>"; };
@@ -281,6 +283,7 @@
 				213398181CDB8BB2003248BD /* ProductProjectionTests.swift */,
 				21D462031D23FD0A00CB8C8E /* CartTests.swift */,
 				21BB6F331DDEF8900010127A /* GraphQLTests.swift */,
+				21DE0C731E70C74E00644A16 /* ShippingMethodTests.swift */,
 			);
 			path = Endpoints;
 			sourceTree = "<group>";
@@ -968,6 +971,7 @@
 				213398191CDB8BB2003248BD /* ProductProjectionTests.swift in Sources */,
 				210BE9FDDE49F1D7D4F53430 /* UpdateByKeyEndpointTests.swift in Sources */,
 				210BEDE9A321298095FE617F /* ByIdEndpointTests.swift in Sources */,
+				21DE0C741E70C74E00644A16 /* ShippingMethodTests.swift in Sources */,
 				210BE27112B084029788BD8A /* QueryEndpointTests.swift in Sources */,
 				2111C3F51CD7831D00B2C082 /* CustomerTests.swift in Sources */,
 				21D462041D23FD0A00CB8C8E /* CartTests.swift in Sources */,

--- a/Commercetools.xcodeproj/project.pbxproj
+++ b/Commercetools.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		210BE2B248108674195B273D /* Order.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEA6FB439BA3428416ADA /* Order.swift */; };
 		210BE2D10EB2727F5D10CC81 /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE42D51680AC2E726E7B8 /* Endpoint.swift */; };
 		210BE2D44101246E68061B67 /* GraphQL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEBECE8C936725065818D /* GraphQL.swift */; };
+		210BE2D697C01367F420B87C /* ShippingMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEA84C889E6D243236304 /* ShippingMethod.swift */; };
 		210BE392D59B8899AAEE6C75 /* DeleteEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEBC1C54EE692BE66C45D /* DeleteEndpoint.swift */; };
 		210BE3F09C3A92C4CF3BBB81 /* QueryEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE274F836CA9FAD68CFE4 /* QueryEndpoint.swift */; };
 		210BE406B8B90BA80629F4E3 /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE33ABEBD530A3C0FE7CC /* Category.swift */; };
@@ -58,6 +59,8 @@
 		210BEA16377561C1FC741F28 /* CreateEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEF918E99658EE26EA2EE /* CreateEndpointTests.swift */; };
 		210BEA28BDE4F67CB57AAFB3 /* GraphQL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEBECE8C936725065818D /* GraphQL.swift */; };
 		210BEA38352FDAF393A0D7AB /* Cart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BED11C155764F3DA2729C /* Cart.swift */; };
+		210BEA4E1FB9634C1A6650FB /* ShippingMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEA84C889E6D243236304 /* ShippingMethod.swift */; };
+		210BEA9F2CC1DF74BF2F2DE8 /* ShippingMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEA84C889E6D243236304 /* ShippingMethod.swift */; };
 		210BEAD8ECB7ACA574E43C10 /* CreateEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE57FB3763B5BD8BC5E5D /* CreateEndpoint.swift */; };
 		210BEAE8EE783B5FE84EBFF4 /* QueryEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE274F836CA9FAD68CFE4 /* QueryEndpoint.swift */; };
 		210BEB11D16D1D795228E4E9 /* ProductType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE39D07091D3D25A8B06A /* ProductType.swift */; };
@@ -69,6 +72,7 @@
 		210BEBDF294FEECEB8FBAA55 /* Customer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE60E5CC237E90996797C /* Customer.swift */; };
 		210BEBEE015A11BAB91AA3A1 /* Order.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEA6FB439BA3428416ADA /* Order.swift */; };
 		210BEC1259A9C0E342538035 /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE42D51680AC2E726E7B8 /* Endpoint.swift */; };
+		210BEC30BE1433FD4D4A7109 /* ShippingMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEA84C889E6D243236304 /* ShippingMethod.swift */; };
 		210BEC5C070AF90D648A3728 /* Cart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BED11C155764F3DA2729C /* Cart.swift */; };
 		210BEC9F114FFE8E9070E63D /* ActiveCart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE5A1F72459DD0112C05F /* ActiveCart.swift */; };
 		210BECAA37F4E4A1C50AD762 /* Order.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEA6FB439BA3428416ADA /* Order.swift */; };
@@ -161,6 +165,7 @@
 		210BE8A23681D90DD2E0EFE3 /* UpdateByKeyEndpoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UpdateByKeyEndpoint.swift; sourceTree = "<group>"; };
 		210BE9843E11F6463E35416E /* ByIdEndpoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ByIdEndpoint.swift; sourceTree = "<group>"; };
 		210BEA6FB439BA3428416ADA /* Order.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Order.swift; sourceTree = "<group>"; };
+		210BEA84C889E6D243236304 /* ShippingMethod.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShippingMethod.swift; sourceTree = "<group>"; };
 		210BEAADF7135452064FD935 /* Log.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
 		210BEAB4E31FF53F0AA955D6 /* ByKeyEndpoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ByKeyEndpoint.swift; sourceTree = "<group>"; };
 		210BEB98C5B6456567B5AF28 /* UpdateEndpoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UpdateEndpoint.swift; sourceTree = "<group>"; };
@@ -328,6 +333,7 @@
 				210BEBECE8C936725065818D /* GraphQL.swift */,
 				210BE39D07091D3D25A8B06A /* ProductType.swift */,
 				210BEA6FB439BA3428416ADA /* Order.swift */,
+				210BEA84C889E6D243236304 /* ShippingMethod.swift */,
 			);
 			name = Endpoints;
 			sourceTree = "<group>";
@@ -848,6 +854,7 @@
 				210BE4604D79AA82DA36A8F9 /* UpdateByKeyEndpoint.swift in Sources */,
 				210BE475FC9BCF9A906987AC /* ByIdEndpoint.swift in Sources */,
 				210BE40FFDA2E01EE5A54A22 /* ByKeyEndpoint.swift in Sources */,
+				210BEC30BE1433FD4D4A7109 /* ShippingMethod.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -879,6 +886,7 @@
 				210BEB823DA19A6FA0023268 /* UpdateByKeyEndpoint.swift in Sources */,
 				210BED16061FB43F884D76BB /* ByIdEndpoint.swift in Sources */,
 				210BEEF8ED165A599CD1CA9A /* ByKeyEndpoint.swift in Sources */,
+				210BE2D697C01367F420B87C /* ShippingMethod.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -910,6 +918,7 @@
 				210BE579EF6051556021A369 /* UpdateByKeyEndpoint.swift in Sources */,
 				210BE25E5B5837356D8C433F /* ByIdEndpoint.swift in Sources */,
 				210BE9806DFCB5A4A341970C /* ByKeyEndpoint.swift in Sources */,
+				210BEA4E1FB9634C1A6650FB /* ShippingMethod.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -941,6 +950,7 @@
 				210BEE77BE1A7738CFD93554 /* UpdateByKeyEndpoint.swift in Sources */,
 				210BED4519DB20D64A6266B8 /* ByIdEndpoint.swift in Sources */,
 				210BE95F83CFD18E6ACA3B11 /* ByKeyEndpoint.swift in Sources */,
+				210BEA9F2CC1DF74BF2F2DE8 /* ShippingMethod.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/Endpoint.swift
+++ b/Source/Endpoint.swift
@@ -128,12 +128,12 @@ public extension Endpoint {
     /**
         This method provides default response handling from all endpoints, providing successful result in dictionary format.
 
-        - parameter token:                    Auth token to be included in the headers.
+        - parameter response:                 Received response.
         - parameter result:                   The code to be executed after processing the response, providing response
                                               in dictionary format in case of a successful result.
     */
     static func handleResponse<T>(_ response: DataResponse<Any>, result: (Result<T>) -> Void) {
-        if let responseDict = response.result.value as? [String: Any], let response = response.response, case 200 ... 299 = response.statusCode {
+        if let responseDict = response.result.value, let response = response.response, case 200 ... 299 = response.statusCode {
             result(Result.success(responseDict))
         } else {
             checkResponseForErrors(response: response, result: result)

--- a/Source/Models.swift
+++ b/Source/Models.swift
@@ -2320,38 +2320,6 @@ public struct ShippingInfo: Mappable {
 
 }
 
-public struct ShippingMethod: Mappable {
-
-    // MARK: - Properties
-
-    public var id: String?
-    public var version: UInt?
-    public var createdAt: Date?
-    public var lastModifiedAt: Date?
-    public var name: String?
-    public var description: String?
-    public var taxCategory: Reference<TaxCategory>?
-    public var zoneRates: [ZoneRate]?
-    public var isDefault: Bool?
-
-    public init?(map: Map) {}
-
-    // MARK: - Mappable
-
-    mutating public func mapping(map: Map) {
-        id               <- map["id"]
-        version          <- map["version"]
-        createdAt        <- (map["createdAt"], ISO8601DateTransform())
-        lastModifiedAt   <- (map["lastModifiedAt"], ISO8601DateTransform())
-        name             <- map["name"]
-        description      <- map["description"]
-        taxCategory      <- map["taxCategory"]
-        zoneRates        <- map["zoneRates"]
-        isDefault        <- map["isDefault"]
-    }
-
-}
-
 public struct ShippingRate: Mappable {
 
     // MARK: - Properties

--- a/Source/Result.swift
+++ b/Source/Result.swift
@@ -31,16 +31,6 @@ public enum Result<T> {
         return !isSuccess
     }
 
-    /// Returns the associated JSON response in dictionary format, if the result is a success, `nil` otherwise.
-    public var json: [String: Any]? {
-        switch self {
-        case .success(let value as [String: Any]):
-            return value
-        default:
-            return nil
-        }
-    }
-
     /// Returns the associated array of error values if the result is a failure, `nil` otherwise.
     public var errors: [Error]? {
         switch self {
@@ -96,6 +86,14 @@ extension Result: CustomDebugStringConvertible {
 }
 
 extension Result where T: Mappable {
+    /// Returns the associated JSON response in dictionary format, if the result is a success, `nil` otherwise.
+    public var json: [String: Any]? {
+        if case .success(let value as [String: Any]) = self {
+            return value
+        }
+        return nil
+    }
+
     /// Returns the associated response, if the result is a success, `nil` otherwise.
     public var model: T? {
         if case .success(let value) = self {
@@ -110,6 +108,14 @@ public protocol ArrayResponse {
 }
 
 extension Result where T: ArrayResponse {
+    /// Returns the associated JSON response in dictionary format, if the result is a success, `nil` otherwise.
+    public var json: [[String: Any]]? {
+        if case .success(let value as [[String: Any]]) = self {
+            return value
+        }
+        return nil
+    }
+
     /// Returns the associated array, if the result is a success, `nil` otherwise.
     public var model: [T.ArrayElement]? {
         if case .success(let value) = self {

--- a/Source/ShippingMethod.swift
+++ b/Source/ShippingMethod.swift
@@ -1,0 +1,92 @@
+//
+// Copyright (c) 2017 Commercetools. All rights reserved.
+//
+
+import Foundation
+import Alamofire
+import ObjectMapper
+
+/**
+    Provides set of interactions for querying and retrieving by UUID for shipping methods. Retrieving a shipping method
+    for a cart, or a location is also provided.
+*/
+public struct ShippingMethod: ByIdEndpoint, QueryEndpoint, Mappable {
+
+    public typealias ResponseType = ShippingMethod
+
+    public static let path = "shipping-methods"
+
+    // MARK: - Shipping method endpoint functionality
+
+    /**
+        Retrieves an array of `ShippingMethod`s available for a particular `Cart`.
+
+        - parameter cart:                     The cart used to retrieve the `ShippingMethod`s.
+        - parameter result:                   The code to be executed after processing the response.
+    */
+    public static func `for`(cart: Cart, result: @escaping (Result<ShippingMethods>) -> Void) {
+        requestWithTokenAndPath(result, { token, path in
+            Alamofire.request(path, parameters: ["cartId": cart.id ?? ""], encoding: URLEncoding.default, headers: self.headers(token))
+            .responseJSON(queue: DispatchQueue.global(), completionHandler: { response in
+                handleResponse(response, result: result)
+            })
+        })
+    }
+
+    /**
+        Retrieves an array of `ShippingMethod`s available for a particular location.
+
+        - parameter country:                  A two-digit country code as per ISO 3166-1 alpha-2.
+        - parameter state:                    Optional state value.
+        - parameter country:                  Optional currency code compliant with ISO 4217.
+        - parameter result:                   The code to be executed after processing the response.
+    */
+    public static func `for`(country: String, state: String? = nil, currency: String? = nil, result: @escaping (Result<ShippingMethods>) -> Void) {
+        requestWithTokenAndPath(result, { token, path in
+            var parameters = ["country": country]
+            if let state = state {
+                parameters["state"] = state
+            }
+            if let currency = currency {
+                parameters["currency"] = currency
+            }
+
+            Alamofire.request(path, parameters: parameters, encoding: URLEncoding.default, headers: self.headers(token))
+            .responseJSON(queue: DispatchQueue.global(), completionHandler: { response in
+                handleResponse(response, result: result)
+            })
+        })
+    }
+
+    // MARK: - Properties
+
+    public var id: String?
+    public var version: UInt?
+    public var createdAt: Date?
+    public var lastModifiedAt: Date?
+    public var name: String?
+    public var description: String?
+    public var taxCategory: Reference<TaxCategory>?
+    public var zoneRates: [ZoneRate]?
+    public var isDefault: Bool?
+
+    public init?(map: Map) {}
+
+    // MARK: - Mappable
+
+    mutating public func mapping(map: Map) {
+        id               <- map["id"]
+        version          <- map["version"]
+        createdAt        <- (map["createdAt"], ISO8601DateTransform())
+        lastModifiedAt   <- (map["lastModifiedAt"], ISO8601DateTransform())
+        name             <- map["name"]
+        description      <- map["description"]
+        taxCategory      <- map["taxCategory"]
+        zoneRates        <- map["zoneRates"]
+        isDefault        <- map["isDefault"]
+    }
+}
+
+public struct ShippingMethods: ArrayResponse {
+    public typealias ArrayElement = ShippingMethod
+}

--- a/Tests/AuthManagerTests.swift
+++ b/Tests/AuthManagerTests.swift
@@ -311,6 +311,6 @@ class AuthManagerTests: XCTestCase {
             }
         })
 
-        waitForExpectations(timeout: 1000, handler: nil)
+        waitForExpectations(timeout: 10, handler: nil)
     }
 }

--- a/Tests/Endpoints/ShippingMethodTests.swift
+++ b/Tests/Endpoints/ShippingMethodTests.swift
@@ -1,0 +1,114 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import XCTest
+@testable import Commercetools
+
+class ShippingMethodTests: XCTestCase {
+
+    private class CreateShippingMethod: CreateEndpoint {
+        typealias ResponseType = ShippingMethod
+        typealias RequestDraft = NoMapping
+        static let path = "shipping-methods"
+    }
+
+    private class CreateZone: CreateEndpoint {
+        typealias ResponseType = Zone
+        typealias RequestDraft = NoMapping
+        static let path = "zones"
+    }
+
+    private class QueryTaxCategory: QueryEndpoint {
+        typealias ResponseType = TaxCategory
+        typealias RequestDraft = NoMapping
+        static let path = "tax-categories"
+    }
+
+    override func setUp() {
+        super.setUp()
+
+        setupProjectManagementConfiguration()
+        let semaphore = DispatchSemaphore(value: 0)
+        AuthManager.sharedInstance.token { token, error in
+            ShippingMethod.query(limit: 1) { result in
+                if result.model!.count == 0 {
+                    QueryTaxCategory.query(limit: 1) { taxCategoryResult in
+                        CreateZone.create(["name": "Germany", "locations": [["country": "DE"]]]) { zoneResult in
+                            CreateShippingMethod.create(["name": "test-shipping-method", "isDefault": true,
+                                                         "zoneRates":[["zone": ["id": zoneResult.model!.id!, "typeId": "zone"],
+                                                                       "shippingRates": [["price": ["currencyCode": "EUR", "centAmount": 1000]]]]],
+                                                         "taxCategory": ["id": taxCategoryResult.model!.results!.first!.id!,
+                                                                         "typeId": "tax-category"]]) { result in
+                                semaphore.signal()
+                            }
+                        }
+                    }
+                } else {
+                    semaphore.signal()
+                }
+            }
+        }
+        _ = semaphore.wait(timeout: DispatchTime.distantFuture)
+
+        cleanPersistedTokens()
+        setupTestConfiguration()
+    }
+
+    override func tearDown() {
+        cleanPersistedTokens()
+        super.tearDown()
+    }
+
+    func testQueryForShippingMethods() {
+        let shippingMethodsExpectation = expectation(description: "shipping methods expectation")
+
+        ShippingMethod.query(predicates: ["name=\"test-shipping-method\""], limit: 1) { result in
+            XCTAssert(result.isSuccess)
+            XCTAssertEqual(result.model?.results?.first?.name, "test-shipping-method")
+            shippingMethodsExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 10, handler: nil)
+    }
+
+    func testShippingMethodsForCountry() {
+        let shippingMethodsExpectation = expectation(description: "shipping methods expectation")
+
+        ShippingMethod.for(country: "DE") { result in
+            XCTAssert(result.isSuccess)
+            XCTAssertEqual(result.model?.filter({ $0.name == "test-shipping-method" }).count, 1)
+            shippingMethodsExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 10, handler: nil)
+    }
+
+    func testShippingMethodsForCart() {
+        let shippingMethodsExpectation = expectation(description: "shipping methods expectation")
+
+        let username = "swift.sdk.test.user2@commercetools.com"
+        let password = "password"
+
+        AuthManager.sharedInstance.loginCustomer(username: username, password: password, completionHandler: { _ in})
+
+        var cartDraft = CartDraft()
+        cartDraft.currency = "EUR"
+        var address = Address()
+        address.country = "DE"
+        cartDraft.shippingAddress = address
+
+        Cart.create(cartDraft, result: { result in
+            if let cart = result.model {
+                XCTAssert(result.isSuccess)
+                ShippingMethod.for(cart: cart) { result in
+                    XCTAssert(result.isSuccess)
+                    XCTAssertEqual(result.model?.filter({ $0.name == "test-shipping-method" }).count, 1)
+                    shippingMethodsExpectation.fulfill()
+                }
+            }
+        })
+
+        waitForExpectations(timeout: 10, handler: nil)
+    }
+}


### PR DESCRIPTION
Up until now, we didn't have to to handle responses from the API which contain arrays as root JSON objects. `Result` and `Endpoint` have been changed to enable array parsing when retrieving the list of shipping methods for a cart, or a location.

Tests for this endpoint will be added shortly after the permissions are updated.