### PR TITLE
Closes #133 Use languageCode instead of locale identifier for product projection search

### DIFF
--- a/Source/Commercetools.swift
+++ b/Source/Commercetools.swift
@@ -17,11 +17,15 @@ public var config: Config? {
     }
     set (newConfig) {
         Config.currentConfig = newConfig
-        // After setting new configuration, we try to obtain the access token
+        // After setting the new configuration, we try to obtain the access token, and cache new project settings
         AuthManager.sharedInstance.token { token, error in
             if let error = error as? CTError {
                 Log.error("Could not obtain auth token "
                         + (error.errorDescription ?? ""))
+            } else {
+                Project.settings { result in
+                    Project.cached = result.model
+                }
             }
         }
     }
@@ -49,6 +53,8 @@ public var authState: AuthManager.TokenState {
 public struct Project: Endpoint, Mappable {
     public typealias ResponseType = Project
     public static let path = ""
+
+    public static var cached: Project?
 
     /**
         Retrieves project settings.

--- a/Source/ProductProjection.swift
+++ b/Source/ProductProjection.swift
@@ -297,10 +297,10 @@ open class ProductProjection: QueryEndpoint, ByIdEndpoint, ByKeyEndpoint, Mappab
         }
 
         let localeIdentifier = locale.identifier.replacingOccurrences(of: "_", with: "-")
-        if projectLanguages?.contains(localeIdentifier) == true {
-            return localeIdentifier
-        } else if let languageCode = locale.languageCode, projectLanguages?.contains(languageCode) == true {
-            return languageCode
+        if let language = projectLanguages?.filter({ $0.hasPrefix(localeIdentifier) }).first {
+            return language
+        } else if let languageCode = locale.languageCode, let language = projectLanguages?.filter({ $0.hasPrefix(languageCode) }).first {
+            return language
         } else {
             return projectLanguages?.first ?? locale.identifier
         }

--- a/Source/ProductProjection.swift
+++ b/Source/ProductProjection.swift
@@ -235,7 +235,11 @@ open class ProductProjection: QueryEndpoint, ByIdEndpoint, ByKeyEndpoint, Mappab
         var params = params ?? [String: Any]()
 
         if let text = text {
-            params["text." + lang.identifier.replacingOccurrences(of: "_", with: "-")] = text
+            if let languageCode = lang.languageCode {
+                params["text." + languageCode.replacingOccurrences(of: "_", with: "-")] = text
+            } else {
+                Log.error("Cannot perform text search for a locale without language code: \(lang)")
+            }
         }
 
         if let fuzzy = fuzzy {

--- a/Tests/Endpoints/ProductProjectionTests.swift
+++ b/Tests/Endpoints/ProductProjectionTests.swift
@@ -30,7 +30,7 @@ class ProductProjectionTests: XCTestCase {
 
         let searchExpectation = expectation(description: "search expectation")
 
-        ProductProjection.search(sort: ["name.en asc"], limit: 10, lang: Locale(identifier: "en"),
+        ProductProjection.search(sort: ["name.en asc"], limit: 10, lang: Locale.current,
                                  text: "Michael Kors", result: { result in
             if let response = result.json, let total = response["total"] as? Int {
                 XCTAssert(result.isSuccess)

--- a/Tests/Endpoints/ProductProjectionTests.swift
+++ b/Tests/Endpoints/ProductProjectionTests.swift
@@ -43,6 +43,20 @@ class ProductProjectionTests: XCTestCase {
         waitForExpectations(timeout: 10, handler: nil)
     }
 
+    func testSearchLanguageFallback() {
+
+        let fallbackExpectation = expectation(description: "fallback expectation")
+
+        ProductProjection.search(lang: Locale(identifier: "sr"), text: "Michael Kors", result: { result in
+            if let response = result.json, let total = response["total"] as? Int {
+                XCTAssertEqual(total, 18)
+                fallbackExpectation.fulfill()
+            }
+        })
+
+        waitForExpectations(timeout: 10, handler: nil)
+    }
+
     func testSearchFacets() {
 
         let searchExpectation = expectation(description: "search expectation")


### PR DESCRIPTION
Found this one out while implementing the localized voice search in Sunrise.