### PR TITLE
Add price tiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Commercetools Swift SDK
 
-![SPHERE.IO icon](https://admin.sphere.io/assets/images/sphere_logo_rgb_long.png)
+<img src="https://raw.githubusercontent.com/commercetools/press-kit/master/PNG/72DPI/CT%20logo%20horizontal%20RGB%2072dpi.png" height="80" />
 
 [![][travis img]][travis]
 [![][cocoapods img]][cocoapods]

--- a/Source/Models.swift
+++ b/Source/Models.swift
@@ -1928,12 +1928,14 @@ public struct Price: Mappable {
 
     // MARK: - Properties
 
+    public var id: String?
     public var value: Money?
     public var country: String?
     public var customerGroup: Reference<CustomerGroup>?
     public var channel: Reference<Channel>?
     public var validFrom: Date?
     public var validUntil: Date?
+    public var tiers: [PriceTier]?
     public var discounted: DiscountedPrice?
     public var custom: [String: Any]?
 
@@ -1942,14 +1944,33 @@ public struct Price: Mappable {
     // MARK: - Mappable
 
     mutating public func mapping(map: Map) {
+        id                 <- map["id"]
         value              <- map["value"]
         country            <- map["country"]
         customerGroup      <- map["customerGroup"]
         channel            <- map["channel"]
         validFrom          <- (map["validFrom"], ISO8601DateTransform())
         validUntil         <- (map["validUntil"], ISO8601DateTransform())
+        tiers              <- map["tiers"]
         discounted         <- map["discounted"]
         custom             <- map["custom"]
+    }
+}
+
+public struct PriceTier: Mappable {
+
+    // MARK: - Properties
+
+    public var minimumQuantity: UInt?
+    public var value: Money?
+
+    public init?(map: Map) {}
+
+    // MARK: - Mappable
+
+    mutating public func mapping(map: Map) {
+        minimumQuantity    <- map["minimumQuantity"]
+        value              <- map["value"]
     }
 }
 


### PR DESCRIPTION
Just added price tiers, even though the mobile clients won't be setting them for a product, it is possible the clients would want to show information retrieved from the tiers array on the POP / PDP (e.g get X items for XX amount of money, instead of XXX).