### PR TITLE
Remove Alamofire

### DIFF
--- a/Commercetools.podspec
+++ b/Commercetools.podspec
@@ -14,7 +14,6 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '2.2'
 
-  s.dependency 'Alamofire', '~> 4.5'
   s.dependency 'ObjectMapper', '~> 2.2'
 
 end

--- a/Podfile
+++ b/Podfile
@@ -2,7 +2,6 @@ use_frameworks!
 platform :ios, '9.3'
 
 def common_pods
-  pod 'Alamofire', '~> 4.0'
   pod 'ObjectMapper', '~> 2.2'
 end
 

--- a/Source/ActiveCart.swift
+++ b/Source/ActiveCart.swift
@@ -3,7 +3,6 @@
 //
 
 import Foundation
-import Alamofire
 import ObjectMapper
 
 /**
@@ -25,11 +24,11 @@ class ActiveCart: Endpoint {
         
         requestWithTokenAndPath(result, { token, path in
             let fullPath = pathWithExpansion(path, expansion: expansion)
-            
-            Alamofire.request(fullPath, parameters: nil, encoding: JSONEncoding.default, headers: self.headers(token))
-                .responseJSON(queue: DispatchQueue.global(), completionHandler: { response in
-                    handleResponse(response, result: result)
-                })
+            let request = self.request(url: fullPath, headers: self.headers(token))
+
+            perform(request: request) { (response: Result<ResponseType>) in
+                result(response)
+            }
         })
     }
 }

--- a/Source/AuthManager.swift
+++ b/Source/AuthManager.swift
@@ -107,7 +107,7 @@ open class AuthManager {
         if let config = Config.currentConfig, let clientId = config.clientId, let clientSecret = config.clientSecret,
         let authData = "\(clientId):\(clientSecret)".data(using: String.Encoding.utf8), config.validate() {
 
-            var headers = Customer.defaultHeaders
+            var headers = defaultHeaders
             headers["Authorization"] = "Basic \(authData.base64EncodedString())"
             return headers
         }

--- a/Source/ByIdEndpoint.swift
+++ b/Source/ByIdEndpoint.swift
@@ -3,7 +3,6 @@
 //
 
 import Foundation
-import Alamofire
 
 /**
     All endpoints capable of being retrieved by UUID should conform to this protocol.
@@ -29,11 +28,11 @@ public extension ByIdEndpoint {
         
         requestWithTokenAndPath(result, { token, path in
             let fullPath = pathWithExpansion(path + id, expansion: expansion)
+            let request = self.request(url: fullPath, headers: self.headers(token))
             
-            Alamofire.request(fullPath, parameters: nil, encoding: JSONEncoding.default, headers: self.headers(token))
-                .responseJSON(queue: DispatchQueue.global(), completionHandler: { response in
-                    handleResponse(response, result: result)
-                })
+            perform(request: request) { (response: Result<ResponseType>) in
+                result(response)
+            }
         })
     }
 }

--- a/Source/ByKeyEndpoint.swift
+++ b/Source/ByKeyEndpoint.swift
@@ -3,7 +3,6 @@
 //
 
 import Foundation
-import Alamofire
 
 /**
     All endpoints capable of being retrieved by key should conform to this protocol.
@@ -29,11 +28,11 @@ public extension ByKeyEndpoint {
         
         requestWithTokenAndPath(result, { token, path in
             let fullPath = pathWithExpansion("\(path)key=\(key)", expansion: expansion)
-            
-            Alamofire.request(fullPath, parameters: nil, encoding: JSONEncoding.default, headers: self.headers(token))
-                .responseJSON(queue: DispatchQueue.global(), completionHandler: { response in
-                    handleResponse(response, result: result)
-                })
+            let request = self.request(url: fullPath, headers: self.headers(token))
+
+            perform(request: request) { (response: Result<ResponseType>) in
+                result(response)
+            }
         })
     }
 }

--- a/Source/Cart.swift
+++ b/Source/Cart.swift
@@ -3,7 +3,6 @@
 //
 
 import Foundation
-import Alamofire
 import ObjectMapper
 
 /**

--- a/Source/Commercetools.swift
+++ b/Source/Commercetools.swift
@@ -3,7 +3,6 @@
 //
 
 import Foundation
-import Alamofire
 import ObjectMapper
 
 // MARK: - Configuration
@@ -30,6 +29,8 @@ public var config: Config? {
         }
     }
 }
+
+let urlSession = URLSession(configuration: URLSessionConfiguration.default)
 
 #if os(watchOS)
 public extension Notification.Name {
@@ -63,10 +64,11 @@ public struct Project: Endpoint, ImmutableMappable {
     */
     public static func settings(result: @escaping (Result<ResponseType>) -> Void) {
         requestWithTokenAndPath(result, { token, path in
-            Alamofire.request(path, headers: self.headers(token))
-            .responseJSON(queue: DispatchQueue.global(), completionHandler: { response in
-                handleResponse(response, result: result)
-            })
+            let request = Customer.request(url: path, headers: self.headers(token))
+
+            perform(request: request) { (response: Result<ResponseType>) in
+                result(response)
+            }
         })
     }
 

--- a/Source/Commercetools.swift
+++ b/Source/Commercetools.swift
@@ -30,8 +30,6 @@ public var config: Config? {
     }
 }
 
-let urlSession = URLSession(configuration: URLSessionConfiguration.default)
-
 #if os(watchOS)
 public extension Notification.Name {
     /// Used as a namespace for all notifications related to watch token synchronization.

--- a/Source/CreateEndpoint.swift
+++ b/Source/CreateEndpoint.swift
@@ -3,7 +3,6 @@
 //
 
 import Foundation
-import Alamofire
 import ObjectMapper
 
 /**
@@ -41,11 +40,11 @@ public extension CreateEndpoint {
 
         requestWithTokenAndPath(result, { token, path in
             let fullPath = pathWithExpansion(path, expansion: expansion)
+            let request = self.request(url: fullPath, method: .post, json: object, headers: self.headers(token))
 
-            Alamofire.request(fullPath, method: .post, parameters: object, encoding: JSONEncoding.default, headers: self.headers(token))
-                    .responseJSON(queue: DispatchQueue.global(), completionHandler: { response in
-                        handleResponse(response, result: result)
-                    })
+            perform(request: request) { (response: Result<ResponseType>) in
+                result(response)
+            }
         })
     }
 

--- a/Source/DeleteEndpoint.swift
+++ b/Source/DeleteEndpoint.swift
@@ -3,7 +3,6 @@
 //
 
 import Foundation
-import Alamofire
 
 /**
     All endpoints capable of being deleted by UUID should conform to this protocol.
@@ -30,11 +29,11 @@ public extension DeleteEndpoint {
         
         requestWithTokenAndPath(result, { token, path in
             let fullPath = pathWithExpansion(path + id, expansion: expansion)
-            
-            Alamofire.request(fullPath, method: .delete, parameters: ["version": version], encoding: URLEncoding.queryString, headers: self.headers(token))
-                .responseJSON(queue: DispatchQueue.global(), completionHandler: { response in
-                    handleResponse(response, result: result)
-                })
+            let request = self.request(url: fullPath, method: .delete, urlParameters: ["version": String(version)], headers: self.headers(token))
+
+            perform(request: request) { (response: Result<ResponseType>) in
+                result(response)
+            }
         })
     }
 }

--- a/Source/Endpoint.swift
+++ b/Source/Endpoint.swift
@@ -171,6 +171,12 @@ public extension Endpoint {
     }
 }
 
+var urlSession: URLSession = {
+    var configuration = URLSessionConfiguration.ephemeral
+    configuration.httpMaximumConnectionsPerHost = 8
+    return URLSession(configuration: configuration)
+}()
+
 /// HTTP method definitions.
 ///
 /// See https://tools.ietf.org/html/rfc7231#section-4.3

--- a/Source/Endpoint.swift
+++ b/Source/Endpoint.swift
@@ -3,7 +3,6 @@
 //
 
 import Foundation
-import Alamofire
 import ObjectMapper
 
 /**
@@ -47,6 +46,22 @@ public extension Endpoint {
                     + (path.hasSuffix("/") ? "" : "/")
         }
         return nil
+    }
+
+    static var defaultHeaders: [String: String] {
+        // Accept-Encoding HTTP Header; see https://tools.ietf.org/html/rfc7230#section-4.2.3
+        let acceptEncoding: String = "gzip;q=1.0, compress;q=0.5"
+        // Accept-Language HTTP Header; see https://tools.ietf.org/html/rfc7231#section-5.3.5
+        let acceptLanguage = Locale.preferredLanguages.prefix(6).enumerated().map { enumeratedLanguage in
+            let (index, languageCode) = enumeratedLanguage
+            let quality = 1.0 - (Double(index) * 0.1)
+            return "\(languageCode);q=\(quality)"
+        }.joined(separator: ", ")
+        return [
+            "Accept-Encoding": acceptEncoding,
+            "Accept-Language": acceptLanguage,
+            "User-Agent": userAgent
+        ]
     }
 
     /// The full user agent header sent with requests to the platform.
@@ -117,42 +132,42 @@ public extension Endpoint {
                    the "Accept-Encoding", "Accept-Language" and "User-Agent" headers.
     */
     static func headers(_ token: String) -> [String: String] {
-        var headers = SessionManager.defaultHTTPHeaders
+        var headers = defaultHeaders
         headers["Authorization"] = "Bearer \(token)"
-        headers["User-Agent"] = userAgent
         return headers
     }
 
     /**
-        This method provides default response handling from all endpoints, providing successful result in dictionary format.
+        This method provides default response handling from all endpoints, providing successful result in dictionary format. TODO update
 
         - parameter response:                 Received response.
         - parameter result:                   The code to be executed after processing the response, providing response
                                               in dictionary format in case of a successful result.
     */
-    static func handleResponse<T>(_ response: DataResponse<Any>, result: (Result<T>) -> Void) {
-        if let responseDict = response.result.value, let response = response.response, case 200 ... 299 = response.statusCode {
+    static func handleResponse<T>(data: Data?, response: URLResponse?, error: Error?, result: (Result<T>) -> Void) {
+        if let data = data, let responseDict = try? JSONSerialization.jsonObject(with: data, options: []), let statusCode = (response as? HTTPURLResponse)?.statusCode, case 200 ... 299 = statusCode {
             result(Result.success(responseDict))
         } else {
-            checkResponseForErrors(response: response, result: result)
+            checkResponseForErrors(data: data, response: response, error: error, result: result)
         }
     }
     
-    static func checkResponseForErrors<T>(response: DataResponse<Any>, result: (Result<T>) -> Void) {
-        if let responseDict = response.result.value as? [String: AnyObject], let response = response.response {
+    static func checkResponseForErrors<T>(data: Data?, response: URLResponse?, error: Error?, result: (Result<T>) -> Void) {
+        if let data = data, let jsonObject = try? JSONSerialization.jsonObject(with: data, options: []),
+           let responseDict = jsonObject as? [String: Any], let statusCode = (response as? HTTPURLResponse)?.statusCode {
             if let errorsResponse = responseDict["errors"] as? [[String: AnyObject]] {
                 var errors = [CTError]()
                 errorsResponse.forEach {
                     errors += [CTError(code: $0["code"] as? String ?? "", failureMessage: $0["message"] as? String,
-                                       failureDetails: $0["detailedErrorMessage"] as? String, currentVersion: $0["currentVersion"] as? UInt)]
+                            failureDetails: $0["detailedErrorMessage"] as? String, currentVersion: $0["currentVersion"] as? UInt)]
                 }
-                result(Result.failure(response.statusCode, errors))
-                
+                result(Result.failure(statusCode, errors))
+
             } else {
-                result(Result.failure(response.statusCode, [CTError.generalError(reason: CTError.FailureReason(message: responseDict["error"] as? String, details: nil))]))
+                result(Result.failure(statusCode, [CTError.generalError(reason: CTError.FailureReason(message: responseDict["error"] as? String, details: nil))]))
             }
         } else {
-            result(Result.failure(response.response?.statusCode, [response.result.error ?? CTError.generalError(reason: nil)]))
+            result(Result.failure((response as? HTTPURLResponse)?.statusCode, [error ?? CTError.generalError(reason: nil)]))
         }
     }
 
@@ -177,4 +192,50 @@ public extension Endpoint {
             requestHandler(token, path)
         }
     }
+
+    static func request(url: String, method: HTTPMethod = .get, urlParameters: [String: String] = [:], json: [String: Any]? = nil, headers: [String: String] = [:]) -> URLRequest {
+        var queryItems = [URLQueryItem]()
+        urlParameters.forEach {
+            queryItems.append(URLQueryItem(name: $0.key, value: $0.value))
+        }
+        return request(url: url, method: method, queryItems: queryItems, json: json, headers: headers)
+    }
+
+    static func request(url: String, method: HTTPMethod = .get, queryItems: [URLQueryItem], json: [String: Any]? = nil, headers: [String: String] = [:]) -> URLRequest {
+        var urlComponents = URLComponents(string: url)!
+        urlComponents.queryItems = queryItems + (urlComponents.queryItems ?? [])
+
+        var urlRequest = URLRequest(url: urlComponents.url!)
+        urlRequest.httpMethod = method.rawValue
+        headers.forEach {
+            urlRequest.addValue($0.value, forHTTPHeaderField: $0.key)
+        }
+
+        if let json = json, let jsonData = try? JSONSerialization.data(withJSONObject: json, options: []) {
+            urlRequest.httpBody = jsonData
+        }
+
+        return urlRequest
+    }
+
+    static func perform<T>(request: URLRequest, result: @escaping (Result<T>) -> Void) {
+        urlSession.dataTask(with: request, completionHandler: { data, response, error in
+            self.handleResponse(data: data, response: response, error: error, result: result)
+        }).resume()
+    }
+}
+
+/// HTTP method definitions.
+///
+/// See https://tools.ietf.org/html/rfc7231#section-4.3
+public enum HTTPMethod: String {
+    case options = "OPTIONS"
+    case get     = "GET"
+    case head    = "HEAD"
+    case post    = "POST"
+    case put     = "PUT"
+    case patch   = "PATCH"
+    case delete  = "DELETE"
+    case trace   = "TRACE"
+    case connect = "CONNECT"
 }

--- a/Source/Endpoint.swift
+++ b/Source/Endpoint.swift
@@ -48,62 +48,6 @@ public extension Endpoint {
         return nil
     }
 
-    static var defaultHeaders: [String: String] {
-        // Accept-Encoding HTTP Header; see https://tools.ietf.org/html/rfc7230#section-4.2.3
-        let acceptEncoding: String = "gzip;q=1.0, compress;q=0.5"
-        // Accept-Language HTTP Header; see https://tools.ietf.org/html/rfc7231#section-5.3.5
-        let acceptLanguage = Locale.preferredLanguages.prefix(6).enumerated().map { enumeratedLanguage in
-            let (index, languageCode) = enumeratedLanguage
-            let quality = 1.0 - (Double(index) * 0.1)
-            return "\(languageCode);q=\(quality)"
-        }.joined(separator: ", ")
-        return [
-            "Accept-Encoding": acceptEncoding,
-            "Accept-Language": acceptLanguage,
-            "User-Agent": userAgent
-        ]
-    }
-
-    /// The full user agent header sent with requests to the platform.
-    static var userAgent: String {
-        let commercetoolsSDK: String = {
-            let commercetoolsSDKVersion = Bundle(for: Config.self).infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
-            return "commercetools-ios-sdk/\(commercetoolsSDKVersion)"
-        }()
-        let osNameVersion: String = {
-            let version = ProcessInfo.processInfo.operatingSystemVersion
-
-            let osName: String = {
-                #if os(iOS)
-                    return "iOS"
-                #elseif os(watchOS)
-                    return "watchOS"
-                #elseif os(tvOS)
-                    return "tvOS"
-                #elseif os(macOS)
-                    return "macOS"
-                #else
-                    return "Unknown"
-                #endif
-            }()
-
-            return "\(osName)/\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
-        }()
-
-        if let info = Bundle.main.infoDictionary {
-            let executable = info[kCFBundleExecutableKey as String] as? String ?? "Unknown"
-            let appVersion = info["CFBundleShortVersionString"] as? String ?? "Unknown"
-
-            if let config = Config.currentConfig, let emergencyContactInfo = config.emergencyContactInfo, config.validate() {
-                return "\(commercetoolsSDK) \(osNameVersion) \(executable)/\(appVersion) (+\(emergencyContactInfo))"
-            }
-
-            return "\(commercetoolsSDK) \(osNameVersion) \(executable)/\(appVersion)"
-        }
-
-        return "\(commercetoolsSDK) \(osNameVersion)"
-    }
-
     /**
         Appends expansion parameters at the end of the provided path.
 
@@ -138,9 +82,11 @@ public extension Endpoint {
     }
 
     /**
-        This method provides default response handling from all endpoints, providing successful result in dictionary format. TODO update
+        This method provides default response handling from all endpoints, providing successful result in dictionary format.
 
-        - parameter response:                 Received response.
+        - parameter response:                 Received `Data`.
+        - parameter response:                 Received `URLResponse`.
+        - parameter response:                 Received `Error`.
         - parameter result:                   The code to be executed after processing the response, providing response
                                               in dictionary format in case of a successful result.
     */
@@ -239,3 +185,61 @@ public enum HTTPMethod: String {
     case trace   = "TRACE"
     case connect = "CONNECT"
 }
+
+var defaultHeaders: [String: String] = {
+    // Accept-Encoding HTTP Header; see https://tools.ietf.org/html/rfc7230#section-4.2.3
+    let acceptEncoding: String = "gzip;q=1.0, compress;q=0.5"
+    // Accept-Language HTTP Header; see https://tools.ietf.org/html/rfc7231#section-5.3.5
+    let acceptLanguage = Locale.preferredLanguages.prefix(6).enumerated().map { enumeratedLanguage in
+        let (index, languageCode) = enumeratedLanguage
+        let quality = 1.0 - (Double(index) * 0.1)
+        return "\(languageCode);q=\(quality)"
+    }.joined(separator: ", ")
+    return [
+        "Accept-Encoding": acceptEncoding,
+        "Accept-Language": acceptLanguage,
+        "User-Agent": userAgent
+    ]
+}()
+
+/// The full user agent header sent with requests to the platform.
+var userAgent: String = {
+    let commercetoolsSDK: String = {
+        let commercetoolsSDKVersion = Bundle(for: Config.self).infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
+        return "commercetools-ios-sdk/\(commercetoolsSDKVersion)"
+    }()
+    let osNameVersion: String = {
+        let version = ProcessInfo.processInfo.operatingSystemVersion
+
+        let osName: String = {
+            #if os(iOS)
+                return "iOS"
+            #elseif os(watchOS)
+                return "watchOS"
+            #elseif os(tvOS)
+                return "tvOS"
+            #elseif os(macOS)
+                return "macOS"
+            #elseif os(Linux)
+                return "Linux"
+            #else
+                return "Unknown"
+            #endif
+        }()
+
+        return "\(osName)/\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
+    }()
+
+    if let info = Bundle.main.infoDictionary {
+        let executable = info[kCFBundleExecutableKey as String] as? String ?? "Unknown"
+        let appVersion = info["CFBundleShortVersionString"] as? String ?? "Unknown"
+
+        if let config = Config.currentConfig, let emergencyContactInfo = config.emergencyContactInfo, config.validate() {
+            return "\(commercetoolsSDK) \(osNameVersion) \(executable)/\(appVersion) (+\(emergencyContactInfo))"
+        }
+
+        return "\(commercetoolsSDK) \(osNameVersion) \(executable)/\(appVersion)"
+    }
+
+    return "\(commercetoolsSDK) \(osNameVersion)"
+}()

--- a/Source/GraphQL.swift
+++ b/Source/GraphQL.swift
@@ -3,7 +3,6 @@
 //
 
 import Foundation
-import Alamofire
 
 /**
     GraphQL endpoint implementation, providing the ability to query for data with queries, passing optional variables and
@@ -32,11 +31,11 @@ open class GraphQL: Endpoint {
             if let operationName = operationName {
                 parameters["operationName"] = operationName
             }
+            let request = self.request(url: path, method: .post, json: parameters, headers: self.headers(token))
 
-            Alamofire.request(path, method: .post, parameters: parameters, encoding: JSONEncoding.default, headers: self.headers(token))
-                    .responseJSON(queue: DispatchQueue.global(), completionHandler: { response in
-                        handleResponse(response, result: result)
-                    })
+            perform(request: request) { (response: Result<ResponseType>) in
+                result(response)
+            }
         })
     }
 }

--- a/Source/ShippingMethod.swift
+++ b/Source/ShippingMethod.swift
@@ -3,7 +3,6 @@
 //
 
 import Foundation
-import Alamofire
 import ObjectMapper
 
 /**
@@ -26,10 +25,11 @@ public struct ShippingMethod: ByIdEndpoint, QueryEndpoint, ImmutableMappable {
     */
     public static func `for`(cart: Cart, result: @escaping (Result<ShippingMethods>) -> Void) {
         requestWithTokenAndPath(result, { token, path in
-            Alamofire.request(path, parameters: ["cartId": cart.id], encoding: URLEncoding.default, headers: self.headers(token))
-            .responseJSON(queue: DispatchQueue.global(), completionHandler: { response in
-                handleResponse(response, result: result)
-            })
+            let request = self.request(url: path, urlParameters: ["cartId": cart.id], headers: self.headers(token))
+
+            perform(request: request) { (response: Result<ShippingMethods>) in
+                result(response)
+            }
         })
     }
 
@@ -51,10 +51,11 @@ public struct ShippingMethod: ByIdEndpoint, QueryEndpoint, ImmutableMappable {
                 parameters["currency"] = currency
             }
 
-            Alamofire.request(path, parameters: parameters, encoding: URLEncoding.default, headers: self.headers(token))
-            .responseJSON(queue: DispatchQueue.global(), completionHandler: { response in
-                handleResponse(response, result: result)
-            })
+            let request = self.request(url: path, urlParameters: parameters, headers: self.headers(token))
+
+            perform(request: request) { (response: Result<ShippingMethods>) in
+                result(response)
+            }
         })
     }
 

--- a/Source/UpdateByKeyEndpoint.swift
+++ b/Source/UpdateByKeyEndpoint.swift
@@ -3,7 +3,6 @@
 //
 
 import Foundation
-import Alamofire
 
 /**
     All endpoints capable of being updated by key should conform to this protocol.
@@ -31,11 +30,11 @@ public extension UpdateByKeyEndpoint {
         
         requestWithTokenAndPath(result, { token, path in
             let fullPath = pathWithExpansion("\(path)key=\(key)", expansion: expansion)
-            
-            Alamofire.request(fullPath, method: .post, parameters: ["version": version, "actions": actions], encoding: JSONEncoding.default, headers: self.headers(token))
-                .responseJSON(queue: DispatchQueue.global(), completionHandler: { response in
-                    handleResponse(response, result: result)
-                })
+            let request = self.request(url: fullPath, method: .post, json: ["version": version, "actions": actions], headers: self.headers(token))
+
+            perform(request: request) { (response: Result<ResponseType>) in
+                result(response)
+            }
         })
     }
 }

--- a/Source/UpdateEndpoint.swift
+++ b/Source/UpdateEndpoint.swift
@@ -3,7 +3,6 @@
 //
 
 import Foundation
-import Alamofire
 import ObjectMapper
 
 /**
@@ -74,11 +73,11 @@ public extension UpdateEndpoint {
 
         requestWithTokenAndPath(result, { token, path in
             let fullPath = pathWithExpansion(path + id, expansion: expansion)
+            let request = self.request(url: fullPath, method: .post, json: actions.toJSON, headers: self.headers(token))
 
-            Alamofire.request(fullPath, method: .post, parameters: actions.toJSON, encoding: JSONEncoding.default, headers: self.headers(token))
-                    .responseJSON(queue: DispatchQueue.global(), completionHandler: { response in
-                        handleResponse(response, result: result)
-                    })
+            perform(request: request) { (response: Result<ResponseType>) in
+                result(response)
+            }
         })
     }
     
@@ -86,11 +85,11 @@ public extension UpdateEndpoint {
         
         requestWithTokenAndPath(result, { token, path in
             let fullPath = pathWithExpansion(path + id, expansion: expansion)
-            
-            Alamofire.request(fullPath, method: .post, parameters: ["version": version, "actions": actions], encoding: JSONEncoding.default, headers: self.headers(token))
-                .responseJSON(queue: DispatchQueue.global(), completionHandler: { response in
-                    handleResponse(response, result: result)
-                })
+            let request = self.request(url: fullPath, method: .post, json: ["version": version, "actions": actions], headers: self.headers(token))
+
+            perform(request: request) { (response: Result<ResponseType>) in
+                result(response)
+            }
         })
     }
 }

--- a/Tests/Endpoints/CustomerTests.swift
+++ b/Tests/Endpoints/CustomerTests.swift
@@ -3,7 +3,6 @@
 //
 
 import XCTest
-import Alamofire
 @testable import Commercetools
 
 class CustomerTests: XCTestCase {
@@ -308,10 +307,11 @@ class CustomerTests: XCTestCase {
                 }
             }
 
-            Alamofire.request("\(path)password-token", method: .post, parameters: ["email": username], encoding: JSONEncoding.default, headers: TestCustomer.headers(token))
-            .responseJSON(queue: DispatchQueue.global(), completionHandler: { response in
-                TestCustomer.handleResponse(response, result: customerResult)
-            })
+            let request = TestCustomer.request(url: "\(path)password-token", method: .post, json: ["email": username], headers: TestCustomer.headers(token))
+
+            TestCustomer.perform(request: request) { (response: Result<NoMapping>) in
+                customerResult(response)
+            }
         }
 
         waitForExpectations(timeout: 10, handler: nil)
@@ -356,10 +356,11 @@ class CustomerTests: XCTestCase {
                     }
 
                     // Now generate email activation token
-                    Alamofire.request("\(path)email-token", method: .post, parameters: ["id": id, "ttlMinutes": 1], encoding: JSONEncoding.default, headers: TestCustomer.headers(token))
-                    .responseJSON(queue: DispatchQueue.global(), completionHandler: { response in
-                        TestCustomer.handleResponse(response, result: customerResult)
-                    })
+                    let request = TestCustomer.request(url: "\(path)email-token", method: .post, json: ["id": id, "ttlMinutes": 1], headers: TestCustomer.headers(token))
+
+                    TestCustomer.perform(request: request) { (response: Result<NoMapping>) in
+                        customerResult(response)
+                    }
                 }
             })
         }


### PR DESCRIPTION
The `Alamofire` has been removed as a dependency, but the `Endpoint` extension will slightly change again when we remove the `ObjectMapper` in favor of Swift 4 `Codable`.