### PR TITLE
Add ExternalAmount to TaxMode, predicate to ShippingMethod & shippingMethodState to ShippingInfo

### DIFF
--- a/Source/Models.swift
+++ b/Source/Models.swift
@@ -1313,6 +1313,7 @@ public enum TaxMode: String, Codable {
 
     case platform = "Platform"
     case external = "External"
+    case externalAmount = "ExternalAmount"
     case disabled = "Disabled"
 }
 

--- a/Source/Models.swift
+++ b/Source/Models.swift
@@ -1230,6 +1230,12 @@ public struct ShippingInfo: Codable {
     public let shippingMethod: Reference<ShippingMethod>?
     public let deliveries: [Delivery]
     public let discountedPrice: DiscountedLineItemPrice?
+    public let shippingMethodState: ShippingMethodState
+}
+
+public enum ShippingMethodState: String, Codable {
+    case doesNotMatchCart = "DoesNotMatchCart"
+    case matchesCart = "MatchesCart"
 }
 
 public struct ShippingRate: Codable {

--- a/Source/ShippingMethod.swift
+++ b/Source/ShippingMethod.swift
@@ -70,6 +70,7 @@ public struct ShippingMethod: ByIdEndpoint, ByKeyEndpoint, QueryEndpoint, Codabl
     public let taxCategory: Reference<TaxCategory>
     public let zoneRates: [ZoneRate]
     public let isDefault: Bool
+    public let predicate: String?
 }
 
 public struct ShippingMethods: ArrayResponse {


### PR DESCRIPTION
While going through release notes, I've identified a few items which should be added to the Swift SDK, so I grouped them in this PR.