### PR TITLE
Add a custom field to the DiscountCode

### DIFF
--- a/Source/Models.swift
+++ b/Source/Models.swift
@@ -649,6 +649,7 @@ public struct DiscountCode: Codable {
     public let references: [GenericReference]
     public let maxApplications: Int?
     public let maxApplicationsPerCustomer: Int?
+    public let custom: JsonValue?
 }
 
 public struct DiscountCodeInfo: Codable {


### PR DESCRIPTION
Added a custom field to the DiscountCode, and tested it by expanding the `discountCodes` from the `Cart` response.