### PR TITLE
Closes #161 Support recovering from invalid access token

### DIFF
--- a/Source/AuthManager.swift
+++ b/Source/AuthManager.swift
@@ -233,6 +233,26 @@ open class AuthManager {
         }
     }
 
+    /**
+        Tries to recover from `invalidToken` error by removing existing `accessToken` from `TokenStore`.
+
+        - parameter completionHandler:  The code to be executed once the token fetching completes.
+    */
+    func recoverFromInvalidTokenError(_ completionHandler: @escaping (String?, Error?) -> Void) {
+        serialQueue.async(execute: {
+            guard self.accessToken != nil else {
+                self.clearAllTokens()
+                return
+            }
+
+            self.accessToken = nil
+            self.tokenValidDate = nil
+            self.state = .noToken
+            Log.debug("Removing access token, trying to recover from .invalidToken error")
+            self.token(completionHandler)
+        })
+    }
+
     // MARK: - Retrieving tokens from the auth API
 
     private func processTokenRequest(_ completionHandler: @escaping (String?, Error?) -> Void) {

--- a/Source/CTError.swift
+++ b/Source/CTError.swift
@@ -109,3 +109,30 @@ extension CTError.FailureReason {
         }
     }
 }
+
+extension CTError: Equatable {
+    public static func ==(lhs: CTError, rhs: CTError) -> Bool {
+        switch (lhs, rhs) {
+            case (.configurationValidationFailed, .configurationValidationFailed), (.invalidToken, .invalidToken):
+                return true
+            case (.accessTokenRetrievalFailed(let lhsReason), .accessTokenRetrievalFailed(reason: let rhsReason)),
+                 (.invalidJsonInputError(let lhsReason), .invalidJsonInputError(let rhsReason)),
+                 (.invalidInputError(let lhsReason), .invalidInputError(let rhsReason)),
+                 (.resourceNotFoundError(let lhsReason), .resourceNotFoundError(let rhsReason)),
+                 (.insufficientTokenGrantTypeError(let lhsReason), .insufficientTokenGrantTypeError(let rhsReason)),
+                 (.generalError(let lhsReason?), .generalError(reason: let rhsReason?)):
+                return lhsReason == rhsReason
+            case (.concurrentModificationError(let lhsReason, let lhsVersion?), .concurrentModificationError(let rhsReason, let rhsVersion?)):
+                return lhsReason == rhsReason && lhsVersion == rhsVersion
+            default:
+                return false
+        }
+
+    }
+}
+
+extension CTError.FailureReason: Equatable {
+    public static func ==(lhs: CTError.FailureReason, rhs: CTError.FailureReason) -> Bool {
+        return lhs.message == rhs.message && lhs.details == rhs.details
+    }
+}


### PR DESCRIPTION
@cneijenhuis - have a look if you get a chance, basically now the SDK will recover if the access tokens were dropped. Added 2 test cases and tested using the client (i.e iOS app).