### PR TITLE
Percent encode plus sign in URL query params

### DIFF
--- a/Source/Endpoint.swift
+++ b/Source/Endpoint.swift
@@ -158,7 +158,8 @@ public extension Endpoint {
         var urlComponents = URLComponents(string: url)!
         urlComponents.queryItems = queryItems + (urlComponents.queryItems ?? [])
 
-        var urlRequest = URLRequest(url: urlComponents.url!)
+        let urlString = urlComponents.string!.replacingOccurrences(of: "+", with: "%2B")
+        var urlRequest = URLRequest(url: URL(string: urlString)!)
         urlRequest.httpMethod = method.rawValue
         headers.forEach {
             urlRequest.setValue($0.value, forHTTPHeaderField: $0.key)


### PR DESCRIPTION
`+` character is valid in a query string, which is stated in the documentation: https://developer.apple.com/documentation/foundation/nsurlcomponents/1407752-queryitems

However, from W3C recommendations for URI addressing (
https://www.w3.org/Addressing/URL/4_URI_Recommentations.html):
_Within the query string, the plus sign is reserved as shorthand notation for a space. Therefore, real plus signs must be encoded._

This PR updates generic method used for generating `URLRequest` used throughout the SDK.