### PR TITLE
Use application/x-www-form-urlencoded for auth and search

### DIFF
--- a/Source/AuthManager.swift
+++ b/Source/AuthManager.swift
@@ -286,7 +286,7 @@ open class AuthManager {
                 parameters["scope"] = scope
             }
 
-            let request = Customer.request(url: loginUrl, method: .post, urlParameters: parameters, headers: authHeaders)
+            let request = Customer.request(url: loginUrl, method: .post, formParameters: parameters, headers: authHeaders)
             urlSession.dataTask(with: request, completionHandler: { data, response, error in
                 self.state = .customerToken
                 self.handleAuthResponse(data: data, response: response, error: error, completionHandler: completionHandler)
@@ -307,7 +307,7 @@ open class AuthManager {
             if let anonymousId = anonymousId {
                 parameters["anonymous_id"] = anonymousId
             }
-            let request = Customer.request(url: authUrl, method: .post, urlParameters: parameters, headers: authHeaders)
+            let request = Customer.request(url: authUrl, method: .post, formParameters: parameters, headers: authHeaders)
             urlSession.dataTask(with: request, completionHandler: { data, response, error in
                 self.state = .anonymousToken
                 self.handleAuthResponse(data: data, response: response, error: error, completionHandler: completionHandler)
@@ -321,7 +321,7 @@ open class AuthManager {
             if let scope = Config.currentConfig?.scope {
                 parameters["scope"] = scope
             }
-            let request = Customer.request(url: authUrl, method: .post, urlParameters: parameters, headers: authHeaders)
+            let request = Customer.request(url: authUrl, method: .post, formParameters: parameters, headers: authHeaders)
             urlSession.dataTask(with: request, completionHandler: { data, response, error in
                 self.state = .plainToken
                 self.handleAuthResponse(data: data, response: response, error: error, completionHandler: completionHandler)
@@ -331,7 +331,7 @@ open class AuthManager {
 
     private func refreshToken(_ completionHandler: @escaping (String?, Error?) -> Void) {
         if let authUrl = clientCredentialsUrl, let authHeaders = authHeaders, let refreshToken = refreshToken {
-            let request = Customer.request(url: authUrl, method: .post, urlParameters: ["grant_type": "refresh_token", "refresh_token": refreshToken], headers: authHeaders)
+            let request = Customer.request(url: authUrl, method: .post, formParameters: ["grant_type": "refresh_token", "refresh_token": refreshToken], headers: authHeaders)
             urlSession.dataTask(with: request, completionHandler: { data, response, error in
                 self.handleAuthResponse(data: data, response: response, error: error, completionHandler: completionHandler)
             }).resume()

--- a/Source/Endpoint.swift
+++ b/Source/Endpoint.swift
@@ -141,7 +141,10 @@ public extension Endpoint {
         }
     }
 
-    static func request(url: String, method: HTTPMethod = .get, urlParameters: [String: String] = [:], json: [String: Any]? = nil, headers: [String: String] = [:]) -> URLRequest {
+    static func request(url: String, method: HTTPMethod = .get, urlParameters: [String: String] = [:], json: [String: Any]? = nil, formParameters: [String: String]? = nil, headers: [String: String] = [:]) -> URLRequest {
+        guard json == nil || formParameters == nil else {
+            fatalError("Cannot use both json and formParameters in the same URLRequest")
+        }
         var queryItems = [URLQueryItem]()
         urlParameters.forEach {
             queryItems.append(URLQueryItem(name: $0.key, value: $0.value))
@@ -151,10 +154,13 @@ public extension Endpoint {
         if let json = json, let data = try? JSONSerialization.data(withJSONObject: json, options: []) {
             jsonData = data
         }
-        return request(url: url, method: method, queryItems: queryItems, json: jsonData, headers: headers)
+        return request(url: url, method: method, queryItems: queryItems, json: jsonData, formParameters: formParameters, headers: headers)
     }
 
-    static func request(url: String, method: HTTPMethod = .get, queryItems: [URLQueryItem], json: Data? = nil, headers: [String: String] = [:]) -> URLRequest {
+    static func request(url: String, method: HTTPMethod = .get, queryItems: [URLQueryItem], json: Data? = nil, formParameters: [String: String]? = nil, headers: [String: String] = [:]) -> URLRequest {
+        guard json == nil || formParameters == nil else {
+            fatalError("Cannot use both json and formParameters in the same URLRequest")
+        }
         var urlComponents = URLComponents(string: url)!
         urlComponents.queryItems = queryItems + (urlComponents.queryItems ?? [])
 
@@ -164,9 +170,13 @@ public extension Endpoint {
         headers.forEach {
             urlRequest.setValue($0.value, forHTTPHeaderField: $0.key)
         }
+        urlRequest.setValue(json != nil ? "application/json" : "application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
 
         if let json = json {
             urlRequest.httpBody = json
+        } else if let formParameters = formParameters, !formParameters.isEmpty {
+            let body = formParameters.map({ "\($0.addingPercentEncoding(withAllowedCharacters: CharacterSet.alphanumerics) ?? "")=\($1.addingPercentEncoding(withAllowedCharacters: CharacterSet.alphanumerics) ?? "")" }).joined(separator: "&")
+            urlRequest.httpBody = body.data(using: .utf8)
         }
 
         return urlRequest

--- a/Source/Endpoint.swift
+++ b/Source/Endpoint.swift
@@ -154,10 +154,11 @@ public extension Endpoint {
         if let json = json, let data = try? JSONSerialization.data(withJSONObject: json, options: []) {
             jsonData = data
         }
-        return request(url: url, method: method, queryItems: queryItems, json: jsonData, formParameters: formParameters, headers: headers)
+
+        return request(url: url, method: method, queryItems: queryItems, json: jsonData, formParameters: formParameters?.map({ FormParameter(key: $0, value: $1) }), headers: headers)
     }
 
-    static func request(url: String, method: HTTPMethod = .get, queryItems: [URLQueryItem], json: Data? = nil, formParameters: [String: String]? = nil, headers: [String: String] = [:]) -> URLRequest {
+    static func request(url: String, method: HTTPMethod = .get, queryItems: [URLQueryItem], json: Data? = nil, formParameters: [FormParameter]? = nil, headers: [String: String] = [:]) -> URLRequest {
         guard json == nil || formParameters == nil else {
             fatalError("Cannot use both json and formParameters in the same URLRequest")
         }
@@ -175,7 +176,7 @@ public extension Endpoint {
         if let json = json {
             urlRequest.httpBody = json
         } else if let formParameters = formParameters, !formParameters.isEmpty {
-            let body = formParameters.map({ "\($0.addingPercentEncoding(withAllowedCharacters: CharacterSet.alphanumerics) ?? "")=\($1.addingPercentEncoding(withAllowedCharacters: CharacterSet.alphanumerics) ?? "")" }).joined(separator: "&")
+            let body = formParameters.map({ "\($0.key.addingPercentEncoding(withAllowedCharacters: CharacterSet.alphanumerics) ?? "")=\($0.value.addingPercentEncoding(withAllowedCharacters: CharacterSet.alphanumerics) ?? "")" }).joined(separator: "&")
             urlRequest.httpBody = body.data(using: .utf8)
         }
 
@@ -292,3 +293,8 @@ var userAgent: String = {
 
     return "\(commercetoolsSDK) \(osNameVersion)"
 }()
+
+public struct FormParameter {
+    public let key: String
+    public let value: String
+}

--- a/Source/ProductProjection.swift
+++ b/Source/ProductProjection.swift
@@ -56,9 +56,9 @@ public struct ProductProjection: QueryEndpoint, ByIdEndpoint, ByKeyEndpoint, Cod
                             priceCurrency: String? = nil, priceCountry: String? = nil, priceCustomerGroup: String? = nil,
                             priceChannel: String? = nil, result: @escaping (Result<SearchResponse>) -> Void) {
 
-        var parameters = queryParameters(predicates: nil, sort: sort, limit: limit, offset: offset)
+        var parameters = formParameters(predicates: nil, sort: sort, limit: limit, offset: offset)
         if let staged = staged {
-            parameters.append(URLQueryItem(name: "staged", value: staged ? "true" : "false"))
+            parameters.append(FormParameter(key: "staged", value: staged ? "true" : "false"))
         }
         parameters += searchParams(lang: lang, text: text, fuzzy: fuzzy, fuzzyLevel: fuzzyLevel, filters: filters,
                 filterQuery: filterQuery, filterFacets: filterFacets, facets: facets, markMatchingVariants: markMatchingVariants,
@@ -67,7 +67,7 @@ public struct ProductProjection: QueryEndpoint, ByIdEndpoint, ByKeyEndpoint, Cod
 
         requestWithTokenAndPath(result, { token, path in
             let fullPath = pathWithExpansion("\(path)search", expansion: expansion)
-            let request = self.request(url: fullPath, queryItems: parameters, headers: self.headers(token))
+            let request = self.request(url: fullPath, method: .post, queryItems: [], formParameters: parameters, headers: self.headers(token))
 
             perform(request: request) { (response: Result<SearchResponse>) in
                 result(response)
@@ -95,7 +95,9 @@ public struct ProductProjection: QueryEndpoint, ByIdEndpoint, ByKeyEndpoint, Cod
         if let staged = staged {
             parameters.append(URLQueryItem(name: "staged", value: staged ? "true" : "false"))
         }
-        parameters += searchParams(fuzzy: fuzzy)
+        if let fuzzy = fuzzy {
+            parameters.append(URLQueryItem(name: "fuzzy", value: fuzzy ? "true" : "false"))
+        }
         parameters.append(URLQueryItem(name: "searchKeywords." + searchLanguage(for: lang), value: searchKeywords))
 
         requestWithTokenAndPath(result, { token, path in
@@ -202,58 +204,58 @@ public struct ProductProjection: QueryEndpoint, ByIdEndpoint, ByKeyEndpoint, Cod
                                      fuzzyLevel: Int? = nil, filters: [String]? = nil, filterQuery: [String]? = nil,
                                      filterFacets: [String]? = nil, facets: [String]? = nil, markMatchingVariants: Bool? = nil,
                                      priceCurrency: String? = nil, priceCountry: String? = nil, priceCustomerGroup: String? = nil,
-                                     priceChannel: String? = nil) -> [URLQueryItem] {
-        var queryItems = [URLQueryItem]()
+                                     priceChannel: String? = nil) -> [FormParameter] {
+        var parameters = [FormParameter]()
 
         if let text = text {
-            queryItems.append(URLQueryItem(name: "text." + searchLanguage(for: lang), value: text))
+            parameters.append(FormParameter(key: "text." + searchLanguage(for: lang), value: text))
         }
 
         if let fuzzy = fuzzy {
-            queryItems.append(URLQueryItem(name: "fuzzy", value: fuzzy ? "true" : "false"))
+            parameters.append(FormParameter(key: "fuzzy", value: fuzzy ? "true" : "false"))
         }
 
         if let fuzzyLevel = fuzzyLevel {
-            queryItems.append(URLQueryItem(name: "fuzzyLevel", value: String(fuzzyLevel)))
+            parameters.append(FormParameter(key: "fuzzyLevel", value: String(fuzzyLevel)))
         }
 
         filters?.forEach {
-            queryItems.append(URLQueryItem(name: "filter", value: $0))
+            parameters.append(FormParameter(key: "filter", value: $0))
         }
 
         filterQuery?.forEach {
-            queryItems.append(URLQueryItem(name: "filter.query", value: $0))
+            parameters.append(FormParameter(key: "filter.query", value: $0))
         }
 
         filterFacets?.forEach {
-            queryItems.append(URLQueryItem(name: "filter.facets", value: $0))
+            parameters.append(FormParameter(key: "filter.facets", value: $0))
         }
 
         facets?.forEach {
-            queryItems.append(URLQueryItem(name: "facet", value: $0))
+            parameters.append(FormParameter(key: "facet", value: $0))
         }
 
         if let markMatchingVariants = markMatchingVariants {
-            queryItems.append(URLQueryItem(name: "markMatchingVariants", value: markMatchingVariants ? "true" : "false"))
+            parameters.append(FormParameter(key: "markMatchingVariants", value: markMatchingVariants ? "true" : "false"))
         }
 
         if let priceCurrency = priceCurrency {
-            queryItems.append(URLQueryItem(name: "priceCurrency", value: priceCurrency))
+            parameters.append(FormParameter(key: "priceCurrency", value: priceCurrency))
         }
 
         if let priceCountry = priceCountry {
-            queryItems.append(URLQueryItem(name: "priceCountry", value: priceCountry))
+            parameters.append(FormParameter(key: "priceCountry", value: priceCountry))
         }
 
         if let priceCustomerGroup = priceCustomerGroup {
-            queryItems.append(URLQueryItem(name: "priceCustomerGroup", value: priceCustomerGroup))
+            parameters.append(FormParameter(key: "priceCustomerGroup", value: priceCustomerGroup))
         }
 
         if let priceChannel = priceChannel {
-            queryItems.append(URLQueryItem(name: "priceChannel", value: priceChannel))
+            parameters.append(FormParameter(key: "priceChannel", value: priceChannel))
         }
 
-        return queryItems
+        return parameters
     }
 
     private static func searchLanguage(for locale: Locale) -> String {

--- a/Source/QueryEndpoint.swift
+++ b/Source/QueryEndpoint.swift
@@ -78,4 +78,23 @@ public extension QueryEndpoint {
         }
         return queryItems
     }
+
+    static func formParameters(predicates: [String]? = nil, sort: [String]? = nil, limit: UInt? = nil,
+                                offset: UInt? = nil) -> [FormParameter] {
+        var parameters = [FormParameter]()
+
+        predicates?.forEach {
+            parameters.append(FormParameter(key: "where", value: $0))
+        }
+        sort?.forEach {
+            parameters.append(FormParameter(key: "sort", value: $0))
+        }
+        if let limit = limit {
+            parameters.append(FormParameter(key: "limit", value: String(limit)))
+        }
+        if let offset = offset {
+            parameters.append(FormParameter(key: "offset", value: String(offset)))
+        }
+        return parameters
+    }
 }


### PR DESCRIPTION
This PR adds support for creating `URLRequests` using `application/x-www-form-urlencoded` `Content-Type`.

`application/x-www-form-urlencoded` is now used for all auth related requests, as well as `ProductProjection` `search` endpoint.