### PR TITLE
Support for in-store carts and orders

### DIFF
--- a/Source/ByIdEndpoint.swift
+++ b/Source/ByIdEndpoint.swift
@@ -23,16 +23,20 @@ public protocol ByIdEndpoint: Endpoint {
 }
 
 public extension ByIdEndpoint {
-    
+
     static func byId(_ id: String, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
-        
-        requestWithTokenAndPath(result, { token, path in
+        byId(id, expansion: expansion, path: Self.path, result: result)
+    }
+
+    static func byId(_ id: String, expansion: [String]? = nil, path: String, result: @escaping (Result<ResponseType>) -> Void) {
+
+        requestWithTokenAndPath(relativePath: path, result: result) { token, path in
             let fullPath = pathWithExpansion(path + id, expansion: expansion)
             let request = self.request(url: fullPath, headers: self.headers(token))
-            
+
             perform(request: request) { (response: Result<ResponseType>) in
                 result(response)
             }
-        })
+        }
     }
 }

--- a/Source/ByKeyEndpoint.swift
+++ b/Source/ByKeyEndpoint.swift
@@ -25,14 +25,14 @@ public protocol ByKeyEndpoint: Endpoint {
 public extension ByKeyEndpoint {
     
     static func byKey(_ key: String, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
-        
-        requestWithTokenAndPath(result, { token, path in
+
+        requestWithTokenAndPath(result: result) { token, path in
             let fullPath = pathWithExpansion("\(path)key=\(key)", expansion: expansion)
             let request = self.request(url: fullPath, headers: self.headers(token))
 
             perform(request: request) { (response: Result<ResponseType>) in
                 result(response)
             }
-        })
+        }
     }
 }

--- a/Source/Cart.swift
+++ b/Source/Cart.swift
@@ -22,7 +22,7 @@ public struct Cart: QueryEndpoint, ByIdEndpoint, CreateEndpoint, UpdateEndpoint,
      
         - parameter expansion:                An optional array of expansion property names.
         - parameter result:                   The code to be executed after processing the response, providing model
-                                               instance in case of a successful result.
+                                              instance in case of a successful result.
      */
     public static func active(expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
         requestWithTokenAndPath(relativePath: "me/active-cart", result: result) { token, path in
@@ -36,6 +36,25 @@ public struct Cart: QueryEndpoint, ByIdEndpoint, CreateEndpoint, UpdateEndpoint,
     }
 
     // MARK: - In store cart
+
+    /**
+        Retrieves the cart with state Active which has the most recent lastModifiedAt, for a store specified by key.
+
+        - parameter storeKey:                 Key referencing the store for cart retrieval.
+        - parameter expansion:                An optional array of expansion property names.
+        - parameter result:                   The code to be executed after processing the response, providing model
+                                              instance in case of a successful result.
+     */
+    public static func active(storeKey: String, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
+        requestWithTokenAndPath(relativePath: "in-store/key=\(storeKey)/me/active-cart", result: result) { token, path in
+            let fullPath = pathWithExpansion(path, expansion: expansion)
+            let request = self.request(url: fullPath, headers: self.headers(token))
+
+            perform(request: request) { (response: Result<ResponseType>) in
+                result(response)
+            }
+        }
+    }
 
     /**
         Queries for carts from a store specified by key.

--- a/Source/Cart.swift
+++ b/Source/Cart.swift
@@ -18,10 +18,10 @@ public struct Cart: QueryEndpoint, ByIdEndpoint, CreateEndpoint, UpdateEndpoint,
     // MARK: - Active cart
 
     /**
-     Retrieves the cart with state Active which has the most recent lastModifiedAt.
+        Retrieves the cart with state Active which has the most recent lastModifiedAt.
      
-         - parameter expansion:                An optional array of expansion property names.
-         - parameter result:                   The code to be executed after processing the response, providing model
+        - parameter expansion:                An optional array of expansion property names.
+        - parameter result:                   The code to be executed after processing the response, providing model
                                                instance in case of a successful result.
      */
     public static func active(expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
@@ -37,31 +37,99 @@ public struct Cart: QueryEndpoint, ByIdEndpoint, CreateEndpoint, UpdateEndpoint,
 
     // MARK: - In store cart
 
-    static func query(storeKey: String, predicates: [String]? = nil, sort: [String]? = nil, expansion: [String]? = nil, limit: UInt? = nil, offset: UInt? = nil, result: @escaping (Result<QueryResponse<ResponseType>>) -> Void) {
+    /**
+        Queries for carts from a store specified by key.
+
+        - parameter storeKey:                 Key referencing the store for query operation.
+        - parameter predicate:                An optional array of predicates used for querying for carts.
+        - parameter sort:                     An optional array of sort options used for sorting the results.
+        - parameter expansion:                An optional array of expansion property names.
+        - parameter limit:                    An optional parameter to limit the number of returned results.
+        - parameter offset:                   An optional parameter to set the offset of the first returned result.
+        - parameter result:                   The code to be executed after processing the response, providing model
+                                              instance in case of a successful result.
+    */
+    public static func query(storeKey: String, predicates: [String]? = nil, sort: [String]? = nil, expansion: [String]? = nil, limit: UInt? = nil, offset: UInt? = nil, result: @escaping (Result<QueryResponse<ResponseType>>) -> Void) {
         query(predicates: predicates, sort: sort, expansion: expansion, limit: limit, offset: offset, path: inStorePath(storeKey: storeKey), result: result)
     }
 
-    static func byId(_ id: String, storeKey: String, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
+    /**
+        Retrieves a cart by UUID from a store specified by key.
+
+        - parameter id:                       Unique ID of the cart to be retrieved.
+        - parameter storeKey:                 Key referencing the store for cart retrieval.
+        - parameter expansion:                An optional array of expansion property names.
+        - parameter result:                   The code to be executed after processing the response, providing model
+                                              instance in case of a successful result.
+    */
+    public static func byId(_ id: String, storeKey: String, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
         byId(id, expansion: expansion, path: inStorePath(storeKey: storeKey), result: result)
     }
 
-    static func create(_ object: [String: Any]?, storeKey: String, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
+    /**
+        Creates new cart in a store specified by key.
+
+        - parameter object:                   Dictionary representation of the cart draft to be created.
+        - parameter storeKey:                 Key referencing the store where the new cart will be created.
+        - parameter expansion:                An optional array of expansion property names.
+        - parameter result:                   The code to be executed after processing the response.
+    */
+    public static func create(_ object: [String: Any]?, storeKey: String, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
         create(object, expansion: expansion, path: inStorePath(storeKey: storeKey), result: result)
     }
 
-    static func create(_ object: RequestDraft, storeKey: String, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
+    /**
+        Creates new cart in a store specified by key.
+
+        - parameter object:                   CartDraft to be created.
+        - parameter storeKey:                 Key referencing the store where the new cart will be created.
+        - parameter expansion:                An optional array of expansion property names.
+        - parameter result:                   The code to be executed after processing the response.
+    */
+    public static func create(_ object: RequestDraft, storeKey: String, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
         create(object, expansion: expansion, path: inStorePath(storeKey: storeKey), result: result)
     }
 
-    static func update(_ id: String, storeKey: String, actions: UpdateActions<UpdateAction>, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
+    /**
+        Updates a cart with the specified UUID in a store.
+
+        - parameter id:                       Unique ID of the cart to be deleted.
+        - parameter storeKey:                 Key referencing the store used for the update.
+        - parameter actions:                  `UpdateActions`instance, containing correct version and update actions.
+        - parameter expansion:                An optional array of expansion property names.
+        - parameter result:                   The code to be executed after processing the response, providing model
+                                              instance in case of a successful result.
+    */
+    public static func update(_ id: String, storeKey: String, actions: UpdateActions<UpdateAction>, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
         update(id, actions: actions, expansion: expansion, path: inStorePath(storeKey: storeKey), result: result)
     }
 
-    static func update(_ id: String, storeKey: String, version: UInt, actions: [[String: Any]], expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
+    /**
+        Updates a cart with the specified UUID in a store.
+
+        - parameter id:                       Unique ID of the cart to be deleted.
+        - parameter storeKey:                 Key referencing the store used for the update.
+        - parameter version:                  Version of the cart (for optimistic concurrency control).
+        - parameter actions:                  An array of actions to be executed, in dictionary representation.
+        - parameter expansion:                An optional array of expansion property names.
+        - parameter result:                   The code to be executed after processing the response, providing model
+                                              instance in case of a successful result.
+    */
+    public static func update(_ id: String, storeKey: String, version: UInt, actions: [[String: Any]], expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
         update(id, version: version, actions: actions, expansion: expansion, path: inStorePath(storeKey: storeKey), result: result)
     }
 
-    static func delete(_ id: String, storeKey: String, version: UInt, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
+    /**
+        Deletes a cart by UUID from a store specified by key.
+
+        - parameter id:                       Unique ID of the cart to be deleted.
+        - parameter storeKey:                 Key referencing the store containing the cart.
+        - parameter version:                  Version of the cart (for optimistic concurrency control).
+        - parameter expansion:                An optional array of expansion property names.
+        - parameter result:                   The code to be executed after processing the response, providing model
+                                              instance in case of a successful result.
+    */
+    public static func delete(_ id: String, storeKey: String, version: UInt, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
         delete(id, version: version, expansion: expansion, path: inStorePath(storeKey: storeKey), result: result)
     }
 

--- a/Source/Cart.swift
+++ b/Source/Cart.swift
@@ -25,7 +25,14 @@ public struct Cart: QueryEndpoint, ByIdEndpoint, CreateEndpoint, UpdateEndpoint,
                                                instance in case of a successful result.
      */
     public static func active(expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
-        return ActiveCart.get(expansion: expansion, result: result)
+        requestWithTokenAndPath(relativePath: "me/active-cart", result: result) { token, path in
+            let fullPath = pathWithExpansion(path, expansion: expansion)
+            let request = self.request(url: fullPath, headers: self.headers(token))
+
+            perform(request: request) { (response: Result<ResponseType>) in
+                result(response)
+            }
+        }
     }
 
     // MARK: - In store cart
@@ -95,32 +102,4 @@ public struct Cart: QueryEndpoint, ByIdEndpoint, CreateEndpoint, UpdateEndpoint,
     public let lastModifiedAt: Date
     public let lastModifiedBy: LastModifiedBy?
     public let itemShippingAddresses: [Address]
-}
-
-/**
-    Provides access to active cart endpoint.
-*/
-struct ActiveCart: Endpoint {
-
-    public typealias ResponseType = Cart
-
-    static let path = "me/active-cart"
-
-    /**
-     Retrieves the cart with state Active which has the most recent lastModifiedAt.
-
-     - parameter expansion:                An optional array of expansion property names.
-     - parameter result:                   The code to be executed after processing the response.
-     */
-    static func get(expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
-
-        requestWithTokenAndPath(result: result) { token, path in
-            let fullPath = pathWithExpansion(path, expansion: expansion)
-            let request = self.request(url: fullPath, headers: self.headers(token))
-
-            perform(request: request) { (response: Result<ResponseType>) in
-                result(response)
-            }
-        }
-    }
 }

--- a/Source/Cart.swift
+++ b/Source/Cart.swift
@@ -15,6 +15,8 @@ public struct Cart: QueryEndpoint, ByIdEndpoint, CreateEndpoint, UpdateEndpoint,
 
     public static let path = "me/carts"
 
+    // MARK: - Active cart
+
     /**
      Retrieves the cart with state Active which has the most recent lastModifiedAt.
      
@@ -24,6 +26,40 @@ public struct Cart: QueryEndpoint, ByIdEndpoint, CreateEndpoint, UpdateEndpoint,
      */
     public static func active(expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
         return ActiveCart.get(expansion: expansion, result: result)
+    }
+
+    // MARK: - In store cart
+
+    static func query(storeKey: String, predicates: [String]? = nil, sort: [String]? = nil, expansion: [String]? = nil, limit: UInt? = nil, offset: UInt? = nil, result: @escaping (Result<QueryResponse<ResponseType>>) -> Void) {
+        query(predicates: predicates, sort: sort, expansion: expansion, limit: limit, offset: offset, path: inStorePath(storeKey: storeKey), result: result)
+    }
+
+    static func byId(_ id: String, storeKey: String, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
+        byId(id, expansion: expansion, path: inStorePath(storeKey: storeKey), result: result)
+    }
+
+    static func create(_ object: [String: Any]?, storeKey: String, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
+        create(object, expansion: expansion, path: inStorePath(storeKey: storeKey), result: result)
+    }
+
+    static func create(_ object: RequestDraft, storeKey: String, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
+        create(object, expansion: expansion, path: inStorePath(storeKey: storeKey), result: result)
+    }
+
+    static func update(_ id: String, storeKey: String, actions: UpdateActions<UpdateAction>, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
+        update(id, actions: actions, expansion: expansion, path: inStorePath(storeKey: storeKey), result: result)
+    }
+
+    static func update(_ id: String, storeKey: String, version: UInt, actions: [[String: Any]], expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
+        update(id, version: version, actions: actions, expansion: expansion, path: inStorePath(storeKey: storeKey), result: result)
+    }
+
+    static func delete(_ id: String, storeKey: String, version: UInt, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
+        delete(id, version: version, expansion: expansion, path: inStorePath(storeKey: storeKey), result: result)
+    }
+
+    private static func inStorePath(storeKey: String) -> String {
+        return "in-store/key=\(storeKey)/me/carts"
     }
 
     // MARK: - Properties
@@ -78,13 +114,13 @@ struct ActiveCart: Endpoint {
      */
     static func get(expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
 
-        requestWithTokenAndPath(result, { token, path in
+        requestWithTokenAndPath(result: result) { token, path in
             let fullPath = pathWithExpansion(path, expansion: expansion)
             let request = self.request(url: fullPath, headers: self.headers(token))
 
             perform(request: request) { (response: Result<ResponseType>) in
                 result(response)
             }
-        })
+        }
     }
 }

--- a/Source/Commercetools.swift
+++ b/Source/Commercetools.swift
@@ -60,13 +60,13 @@ public struct Project: Endpoint, Codable {
         - parameter result:                   The code to be executed after processing the response.
     */
     public static func settings(result: @escaping (Result<ResponseType>) -> Void) {
-        requestWithTokenAndPath(result, { token, path in
+        requestWithTokenAndPath(result: result) { token, path in
             let request = Customer.request(url: path, headers: self.headers(token))
 
             perform(request: request) { (response: Result<ResponseType>) in
                 result(response)
             }
-        })
+        }
     }
     
     public struct Messages: Codable {

--- a/Source/CreateEndpoint.swift
+++ b/Source/CreateEndpoint.swift
@@ -36,28 +36,36 @@ public protocol CreateEndpoint: Endpoint {
 public extension CreateEndpoint {
 
     static func create(_ object: [String: Any]?, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
+        create(object, expansion: expansion, path: Self.path, result: result)
+    }
 
-        requestWithTokenAndPath(result, { token, path in
+    static func create(_ object: [String: Any]?, expansion: [String]? = nil, path: String, result: @escaping (Result<ResponseType>) -> Void) {
+
+        requestWithTokenAndPath(relativePath: path, result: result) { token, path in
             let fullPath = pathWithExpansion(path, expansion: expansion)
             let request = self.request(url: fullPath, method: .post, json: object, headers: self.headers(token))
 
             perform(request: request) { (response: Result<ResponseType>) in
                 result(response)
             }
-        })
+        }
     }
 
     static func create(_ object: RequestDraft, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
+        create(object, expansion: expansion, path: Self.path, result: result)
+    }
+
+    static func create(_ object: RequestDraft, expansion: [String]? = nil, path: String, result: @escaping (Result<ResponseType>) -> Void) {
         do {
             let data = try jsonEncoder.encode(object)
-            requestWithTokenAndPath(result, { token, path in
+            requestWithTokenAndPath(relativePath: path, result: result) { token, path in
                 let fullPath = pathWithExpansion(path, expansion: expansion)
                 let request = self.request(url: fullPath, method: .post, queryItems: [], json: data, headers: self.headers(token))
                 
                 perform(request: request) { (response: Result<ResponseType>) in
                     result(response)
                 }
-            })
+            }
         } catch {
             Log.error(error.localizedDescription)
         }

--- a/Source/Customer.swift
+++ b/Source/Customer.swift
@@ -40,13 +40,13 @@ public class Customer: Endpoint, Codable {
         if let activeCartSignInMode = activeCartSignInMode {
             userDetails["activeCartSignInMode"] = activeCartSignInMode.rawValue
         }
-        requestWithTokenAndPath(result, { token, path in
+        requestWithTokenAndPath(result: result) { token, path in
             let request = self.request(url: "\(path)login", method: .post, json: userDetails, headers: self.headers(token))
 
             perform(request: request) { (response: Result<CustomerSignInResult>) in
                 result(response)
             }
-        })
+        }
     }
 
     /**
@@ -56,13 +56,13 @@ public class Customer: Endpoint, Codable {
         - parameter result:                   The code to be executed after processing the response.
     */
     static func signUp(_ profile: Data, result: @escaping (Result<CustomerSignInResult>) -> Void) {
-        requestWithTokenAndPath(result, { token, path in
+        requestWithTokenAndPath(result: result) { token, path in
             let request = self.request(url: "\(path)signup", method: .post, queryItems: [], json: profile, headers: self.headers(token))
 
             perform(request: request) { (response: Result<CustomerSignInResult>) in
                 result(response)
             }
-        })
+        }
     }
 
     /**
@@ -190,7 +190,7 @@ public class Customer: Endpoint, Codable {
                                               urlParameters: [String: String] = [:], json: [String: Any]? = nil,
                                               result: @escaping (Result<ResponseType>) -> Void) {
 
-        requestWithTokenAndPath(result, { token, path in
+        requestWithTokenAndPath(result: result) { token, path in
             let fullPath = pathWithExpansion(path, expansion: expansion)
             let request = self.request(url: fullPath + (basePath ?? ""), method: method, urlParameters: urlParameters,
                                        json: json, headers: self.headers(token))
@@ -198,6 +198,6 @@ public class Customer: Endpoint, Codable {
             perform(request: request) { (response: Result<ResponseType>) in
                 result(response)
             }
-        })
+        }
     }
 }

--- a/Source/DeleteEndpoint.swift
+++ b/Source/DeleteEndpoint.swift
@@ -24,16 +24,20 @@ public protocol DeleteEndpoint: Endpoint {
 }
 
 public extension DeleteEndpoint {
-    
+
     static func delete(_ id: String, version: UInt, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
-        
-        requestWithTokenAndPath(result, { token, path in
+        delete(id, version: version, expansion: expansion, path: Self.path, result: result)
+    }
+
+    static func delete(_ id: String, version: UInt, expansion: [String]? = nil, path: String, result: @escaping (Result<ResponseType>) -> Void) {
+
+        requestWithTokenAndPath(relativePath: path, result: result) { token, path in
             let fullPath = pathWithExpansion(path + id, expansion: expansion)
             let request = self.request(url: fullPath, method: .delete, urlParameters: ["version": String(version)], headers: self.headers(token))
 
             perform(request: request) { (response: Result<ResponseType>) in
                 result(response)
             }
-        })
+        }
     }
 }

--- a/Source/Endpoint.swift
+++ b/Source/Endpoint.swift
@@ -36,9 +36,9 @@ public struct NoMapping: Codable {}
 public extension Endpoint {
 
     /// The full path used to form requests for endpoints.
-    static var fullPath: String? {
+    static func fullPath(relativePath: String = Self.path) -> String? {
         if let config = Config.currentConfig, let apiUrl = config.apiUrl, let projectKey = config.projectKey {
-            var normalizedPath = path
+            var normalizedPath = relativePath
             if normalizedPath.hasPrefix("/") {
                 normalizedPath.remove(at: String.Index(encodedOffset: 0))
             }
@@ -125,8 +125,8 @@ public extension Endpoint {
         - parameter result:                   The code to be executed in case an error occurs.
         - parameter requestHandler:           The code to be executed if no error occurs, providing token and path.
     */
-    static func requestWithTokenAndPath<T>(_ result: @escaping (Result<T>) -> Void, _ requestHandler: @escaping (String, String) -> Void) {
-        guard let config = Config.currentConfig, let path = fullPath, config.validate() else {
+    static func requestWithTokenAndPath<T>(relativePath: String = Self.path, result: @escaping (Result<T>) -> Void, requestHandler: @escaping (String, String) -> Void) {
+        guard let config = Config.currentConfig, let path = fullPath(relativePath: relativePath), config.validate() else {
             Log.error("Cannot execute command - check if the configuration is valid.")
             result(Result.failure(nil, [CTError.generalError(reason: nil)]))
             return

--- a/Source/GraphQL.swift
+++ b/Source/GraphQL.swift
@@ -23,7 +23,7 @@ public struct GraphQL: Endpoint {
         - parameter result:                   The code to be executed after processing the response.
     */
     public static func query(_ query: String, variables: [String: Any]? = nil, operationName: String? = nil, result: @escaping (Result<ResponseType>) -> Void) {
-        requestWithTokenAndPath(result, { token, path in
+        requestWithTokenAndPath(result: result) { token, path in
             var parameters: [String: Any] = ["query": query]
             if let variables = variables {
                 parameters["variables"] = variables
@@ -36,6 +36,6 @@ public struct GraphQL: Endpoint {
             perform(request: request) { (response: Result<ResponseType>) in
                 result(response)
             }
-        })
+        }
     }
 }

--- a/Source/Order.swift
+++ b/Source/Order.swift
@@ -55,21 +55,58 @@ public struct Order: QueryEndpoint, ByIdEndpoint, CreateEndpoint, Codable {
     public let origin: CartOrigin
     public let itemShippingAddresses: [Address]
 
-    // MARK: - In store cart
+    // MARK: - In store order
 
-    static func query(storeKey: String, predicates: [String]? = nil, sort: [String]? = nil, expansion: [String]? = nil, limit: UInt? = nil, offset: UInt? = nil, result: @escaping (Result<QueryResponse<ResponseType>>) -> Void) {
+    /**
+        Queries for orders from a store specified by key.
+
+        - parameter storeKey:                 Key referencing the store for query operation.
+        - parameter predicate:                An optional array of predicates used for querying for orders.
+        - parameter sort:                     An optional array of sort options used for sorting the results.
+        - parameter expansion:                An optional array of expansion property names.
+        - parameter limit:                    An optional parameter to limit the number of returned results.
+        - parameter offset:                   An optional parameter to set the offset of the first returned result.
+        - parameter result:                   The code to be executed after processing the response, providing model
+                                              instance in case of a successful result.
+    */
+    public static func query(storeKey: String, predicates: [String]? = nil, sort: [String]? = nil, expansion: [String]? = nil, limit: UInt? = nil, offset: UInt? = nil, result: @escaping (Result<QueryResponse<ResponseType>>) -> Void) {
         query(predicates: predicates, sort: sort, expansion: expansion, limit: limit, offset: offset, path: inStorePath(storeKey: storeKey), result: result)
     }
 
-    static func byId(_ id: String, storeKey: String, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
+    /**
+        Retrieves an order by UUID from a store specified by key.
+
+        - parameter id:                       Unique ID of the order to be retrieved.
+        - parameter storeKey:                 Key referencing the store for order retrieval.
+        - parameter expansion:                An optional array of expansion property names.
+        - parameter result:                   The code to be executed after processing the response, providing model
+                                              instance in case of a successful result.
+    */
+    public static func byId(_ id: String, storeKey: String, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
         byId(id, expansion: expansion, path: inStorePath(storeKey: storeKey), result: result)
     }
 
-    static func create(_ object: [String: Any]?, storeKey: String, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
+    /**
+        Creates new order in a store specified by key.
+
+        - parameter object:                   Dictionary representation of the order draft to be created.
+        - parameter storeKey:                 Key referencing the store where the new order will be created.
+        - parameter expansion:                An optional array of expansion property names.
+        - parameter result:                   The code to be executed after processing the response.
+    */
+    public static func create(_ object: [String: Any]?, storeKey: String, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
         create(object, expansion: expansion, path: inStorePath(storeKey: storeKey), result: result)
     }
 
-    static func create(_ object: RequestDraft, storeKey: String, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
+    /**
+        Creates new order in a store specified by key.
+
+        - parameter object:                   OrderDraft to be created.
+        - parameter storeKey:                 Key referencing the store where the new order will be created.
+        - parameter expansion:                An optional array of expansion property names.
+        - parameter result:                   The code to be executed after processing the response.
+    */
+    public static func create(_ object: RequestDraft, storeKey: String, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
         create(object, expansion: expansion, path: inStorePath(storeKey: storeKey), result: result)
     }
 

--- a/Source/Order.swift
+++ b/Source/Order.swift
@@ -54,4 +54,26 @@ public struct Order: QueryEndpoint, ByIdEndpoint, CreateEndpoint, Codable {
     public let inventoryMode: InventoryMode
     public let origin: CartOrigin
     public let itemShippingAddresses: [Address]
+
+    // MARK: - In store cart
+
+    static func query(storeKey: String, predicates: [String]? = nil, sort: [String]? = nil, expansion: [String]? = nil, limit: UInt? = nil, offset: UInt? = nil, result: @escaping (Result<QueryResponse<ResponseType>>) -> Void) {
+        query(predicates: predicates, sort: sort, expansion: expansion, limit: limit, offset: offset, path: inStorePath(storeKey: storeKey), result: result)
+    }
+
+    static func byId(_ id: String, storeKey: String, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
+        byId(id, expansion: expansion, path: inStorePath(storeKey: storeKey), result: result)
+    }
+
+    static func create(_ object: [String: Any]?, storeKey: String, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
+        create(object, expansion: expansion, path: inStorePath(storeKey: storeKey), result: result)
+    }
+
+    static func create(_ object: RequestDraft, storeKey: String, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
+        create(object, expansion: expansion, path: inStorePath(storeKey: storeKey), result: result)
+    }
+
+    private static func inStorePath(storeKey: String) -> String {
+        return "in-store/key=\(storeKey)/me/orders"
+    }
 }

--- a/Source/ProductProjection.swift
+++ b/Source/ProductProjection.swift
@@ -65,14 +65,14 @@ public struct ProductProjection: QueryEndpoint, ByIdEndpoint, ByKeyEndpoint, Cod
                 priceCurrency: priceCurrency, priceCountry: priceCountry, priceCustomerGroup: priceCustomerGroup,
                 priceChannel: priceChannel)
 
-        requestWithTokenAndPath(result, { token, path in
+        requestWithTokenAndPath(result: result) { token, path in
             let fullPath = pathWithExpansion("\(path)search", expansion: expansion)
             let request = self.request(url: fullPath, method: .post, queryItems: [], formParameters: parameters, headers: self.headers(token))
 
             perform(request: request) { (response: Result<SearchResponse>) in
                 result(response)
             }
-        })
+        }
     }
 
     /**
@@ -100,13 +100,13 @@ public struct ProductProjection: QueryEndpoint, ByIdEndpoint, ByKeyEndpoint, Cod
         }
         parameters.append(URLQueryItem(name: "searchKeywords." + searchLanguage(for: lang), value: searchKeywords))
 
-        requestWithTokenAndPath(result, { token, path in
+        requestWithTokenAndPath(result: result) { token, path in
             let request = self.request(url: "\(path)suggest", queryItems: parameters, headers: self.headers(token))
 
             perform(request: request) { (response: Result<NoMapping>) in
                 result(response)
             }
-        })
+        }
     }
 
     /**
@@ -124,7 +124,7 @@ public struct ProductProjection: QueryEndpoint, ByIdEndpoint, ByKeyEndpoint, Cod
     public static func query(staged: Bool? = nil, predicates: [String]? = nil, sort: [String]? = nil, expansion: [String]? = nil,
                            limit: UInt? = nil, offset: UInt? = nil, result: @escaping (Result<QueryResponse<ResponseType>>) -> Void) {
 
-        requestWithTokenAndPath(result, { token, path in
+        requestWithTokenAndPath(result: result) { token, path in
             let fullPath = pathWithExpansion(path, expansion: expansion)
 
             var parameters = queryParameters(predicates: predicates, sort: sort, limit: limit, offset: offset)
@@ -137,7 +137,7 @@ public struct ProductProjection: QueryEndpoint, ByIdEndpoint, ByKeyEndpoint, Cod
             perform(request: request) { (response: Result<QueryResponse<ResponseType>>) in
                 result(response)
             }
-        })
+        }
     }
 
     /**
@@ -151,7 +151,7 @@ public struct ProductProjection: QueryEndpoint, ByIdEndpoint, ByKeyEndpoint, Cod
     */
     public static func byId(_ id: String, staged: Bool? = nil, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
 
-        requestWithTokenAndPath(result, { token, path in
+        requestWithTokenAndPath(result: result) { token, path in
             let fullPath = pathWithExpansion(path + id, expansion: expansion)
 
             var parameters = [URLQueryItem]()
@@ -164,7 +164,7 @@ public struct ProductProjection: QueryEndpoint, ByIdEndpoint, ByKeyEndpoint, Cod
             perform(request: request) { (response: Result<ResponseType>) in
                 result(response)
             }
-        })
+        }
     }
 
     // MARK: - Properties

--- a/Source/QueryEndpoint.swift
+++ b/Source/QueryEndpoint.swift
@@ -22,8 +22,7 @@ public protocol QueryEndpoint: Endpoint {
         - parameter result:                   The code to be executed after processing the response, providing model
                                               instance in case of a successful result.
     */
-    static func query(predicates: [String]?, sort: [String]?, expansion: [String]?,
-                      limit: UInt?, offset: UInt?, result: @escaping (Result<QueryResponse<ResponseType>>) -> Void)
+    static func query(predicates: [String]?, sort: [String]?, expansion: [String]?, limit: UInt?, offset: UInt?, result: @escaping (Result<QueryResponse<ResponseType>>) -> Void)
 
 }
 
@@ -45,11 +44,14 @@ public class QueryResponse<ResponseType: Codable>: Codable {
 }
 
 public extension QueryEndpoint {
-    
-    static func query(predicates: [String]? = nil, sort: [String]? = nil, expansion: [String]? = nil,
-                      limit: UInt? = nil, offset: UInt? = nil, result: @escaping (Result<QueryResponse<ResponseType>>) -> Void) {
-        
-        requestWithTokenAndPath(result, { token, path in
+
+    static func query(predicates: [String]? = nil, sort: [String]? = nil, expansion: [String]? = nil, limit: UInt? = nil, offset: UInt? = nil, result: @escaping (Result<QueryResponse<ResponseType>>) -> Void) {
+        query(predicates: predicates, sort: sort, expansion: expansion, limit: limit, offset: offset, path: Self.path, result: result)
+    }
+
+    static func query(predicates: [String]? = nil, sort: [String]? = nil, expansion: [String]? = nil, limit: UInt? = nil, offset: UInt? = nil, path: String, result: @escaping (Result<QueryResponse<ResponseType>>) -> Void) {
+
+        requestWithTokenAndPath(relativePath: path, result: result) { token, path in
             let fullPath = pathWithExpansion(path, expansion: expansion)
             let parameters = queryParameters(predicates: predicates, sort: sort, limit: limit, offset: offset)
             let request = self.request(url: fullPath, queryItems: parameters, headers: self.headers(token))
@@ -57,11 +59,10 @@ public extension QueryEndpoint {
             perform(request: request) { (response: Result<QueryResponse<ResponseType>>) in
                 result(response)
             }
-        })
+        }
     }
 
-    static func queryParameters(predicates: [String]? = nil, sort: [String]? = nil, limit: UInt? = nil,
-                                offset: UInt? = nil) -> [URLQueryItem] {
+    static func queryParameters(predicates: [String]? = nil, sort: [String]? = nil, limit: UInt? = nil, offset: UInt? = nil) -> [URLQueryItem] {
         var queryItems = [URLQueryItem]()
 
         predicates?.forEach {
@@ -79,8 +80,7 @@ public extension QueryEndpoint {
         return queryItems
     }
 
-    static func formParameters(predicates: [String]? = nil, sort: [String]? = nil, limit: UInt? = nil,
-                                offset: UInt? = nil) -> [FormParameter] {
+    static func formParameters(predicates: [String]? = nil, sort: [String]? = nil, limit: UInt? = nil, offset: UInt? = nil) -> [FormParameter] {
         var parameters = [FormParameter]()
 
         predicates?.forEach {

--- a/Source/ShippingMethod.swift
+++ b/Source/ShippingMethod.swift
@@ -23,13 +23,13 @@ public struct ShippingMethod: ByIdEndpoint, ByKeyEndpoint, QueryEndpoint, Codabl
         - parameter result:                   The code to be executed after processing the response.
     */
     public static func `for`(cart: Cart, result: @escaping (Result<ShippingMethods>) -> Void) {
-        requestWithTokenAndPath(result, { token, path in
+        requestWithTokenAndPath(result: result) { token, path in
             let request = self.request(url: path, urlParameters: ["cartId": cart.id], headers: self.headers(token))
 
             perform(request: request) { (response: Result<ShippingMethods>) in
                 result(response)
             }
-        })
+        }
     }
 
     /**
@@ -41,7 +41,7 @@ public struct ShippingMethod: ByIdEndpoint, ByKeyEndpoint, QueryEndpoint, Codabl
         - parameter result:                   The code to be executed after processing the response.
     */
     public static func `for`(country: String, state: String? = nil, currency: String? = nil, result: @escaping (Result<ShippingMethods>) -> Void) {
-        requestWithTokenAndPath(result, { token, path in
+        requestWithTokenAndPath(result: result) { token, path in
             var parameters = ["country": country]
             if let state = state {
                 parameters["state"] = state
@@ -55,7 +55,7 @@ public struct ShippingMethod: ByIdEndpoint, ByKeyEndpoint, QueryEndpoint, Codabl
             perform(request: request) { (response: Result<ShippingMethods>) in
                 result(response)
             }
-        })
+        }
     }
 
     // MARK: - Properties

--- a/Source/UpdateByKeyEndpoint.swift
+++ b/Source/UpdateByKeyEndpoint.swift
@@ -27,14 +27,14 @@ public protocol UpdateByKeyEndpoint: Endpoint {
 public extension UpdateByKeyEndpoint {
     
     static func updateByKey(_ key: String, version: UInt, actions: [[String: Any]], expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
-        
-        requestWithTokenAndPath(result, { token, path in
+
+        requestWithTokenAndPath(result: result) { token, path in
             let fullPath = pathWithExpansion("\(path)key=\(key)", expansion: expansion)
             let request = self.request(url: fullPath, method: .post, json: ["version": version, "actions": actions], headers: self.headers(token))
 
             perform(request: request) { (response: Result<ResponseType>) in
                 result(response)
             }
-        })
+        }
     }
 }

--- a/Source/UpdateEndpoint.swift
+++ b/Source/UpdateEndpoint.swift
@@ -69,27 +69,35 @@ public struct UpdateActions<T: JSONRepresentable>: JSONRepresentable {
 public extension UpdateEndpoint {
 
     static func update(_ id: String, actions: UpdateActions<UpdateAction>, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
+        update(id, actions: actions, expansion: expansion, path: Self.path, result: result)
+    }
 
-        requestWithTokenAndPath(result, { token, path in
+    static func update(_ id: String, actions: UpdateActions<UpdateAction>, expansion: [String]? = nil, path: String, result: @escaping (Result<ResponseType>) -> Void) {
+
+        requestWithTokenAndPath(relativePath: path, result: result) { token, path in
             let fullPath = pathWithExpansion(path + id, expansion: expansion)
             let request = self.request(url: fullPath, method: .post, json: actions.toJSON, headers: self.headers(token))
 
             perform(request: request) { (response: Result<ResponseType>) in
                 result(response)
             }
-        })
+        }
     }
-    
+
     static func update(_ id: String, version: UInt, actions: [[String: Any]], expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
-        
-        requestWithTokenAndPath(result, { token, path in
+        update(id, version: version, actions: actions, expansion: expansion, path: Self.path, result: result)
+    }
+
+    static func update(_ id: String, version: UInt, actions: [[String: Any]], expansion: [String]? = nil, path: String, result: @escaping (Result<ResponseType>) -> Void) {
+
+        requestWithTokenAndPath(relativePath: path, result: result) { token, path in
             let fullPath = pathWithExpansion(path + id, expansion: expansion)
             let request = self.request(url: fullPath, method: .post, json: ["version": version, "actions": actions], headers: self.headers(token))
 
             perform(request: request) { (response: Result<ResponseType>) in
                 result(response)
             }
-        })
+        }
     }
 }
 

--- a/Tests/PlatformEndpoints/CustomerTests.swift
+++ b/Tests/PlatformEndpoints/CustomerTests.swift
@@ -289,7 +289,7 @@ class CustomerTests: XCTestCase {
 
         // Obtain password reset token
         AuthManager.sharedInstance.token { token, error in
-            guard let token = token, let path = TestCustomer.fullPath else { return }
+            guard let token = token, let path = TestCustomer.fullPath() else { return }
             
             let customerResult: ((Commercetools.Result<NoMapping>) -> Void) = { result in
                 if let response = result.json, let token = response["value"] as? String, result.isSuccess {
@@ -324,12 +324,12 @@ class CustomerTests: XCTestCase {
         let username = "swift.sdk.test.user2@commercetools.com"
         let password = "password"
 
-        // For generating account activation token we need higher priviledges
+        // For generating account activation token we need higher privileges
         setupProjectManagementConfiguration()
 
         // Obtain password reset token
         AuthManager.sharedInstance.token { token, error in
-            guard let token = token, let path = TestCustomer.fullPath else {
+            guard let token = token, let path = TestCustomer.fullPath() else {
                 return
             }
 

--- a/Tests/PlatformEndpoints/StoreTests.swift
+++ b/Tests/PlatformEndpoints/StoreTests.swift
@@ -169,7 +169,14 @@ class StoreTests: XCTestCase {
                         XCTAssert(result.isSuccess)
 
                         XCTAssertEqual(result.model!.results.first!.store!.key, self.storeKey)
-                        storeExpectation.fulfill()
+
+                        Cart.active(storeKey: self.storeKey) { result in
+                            XCTAssert(result.isSuccess)
+
+                            XCTAssertEqual(result.model!.store!.key, self.storeKey)
+                            XCTAssertEqual(result.model!.id, cart.id)
+                            storeExpectation.fulfill()
+                        }
                     }
                 }
             }

--- a/Tests/PlatformEndpoints/StoreTests.swift
+++ b/Tests/PlatformEndpoints/StoreTests.swift
@@ -15,6 +15,8 @@ class StoreTests: XCTestCase {
 
     private var storeId: String!
 
+    private let storeKey = "unionSquare"
+
     override func setUp() {
         super.setUp()
 
@@ -23,7 +25,7 @@ class StoreTests: XCTestCase {
         // For creating a store we need higher privileges
         setupProjectManagementConfiguration()
 
-        TestStore.create(["key": "unionSquare", "name": ["en": "Union Square"]]) { result in
+        TestStore.create(["key": storeKey, "name": ["en": "Union Square"]]) { result in
             guard let store = result.model, result.isSuccess else {
                 semaphore.signal()
                 return
@@ -59,7 +61,7 @@ class StoreTests: XCTestCase {
 
         Store.byId(storeId) { result in
             XCTAssert(result.isSuccess)
-            XCTAssertEqual(result.model!.key, "unionSquare")
+            XCTAssertEqual(result.model!.key, self.storeKey)
             XCTAssertEqual(result.model!.name!["en"], "Union Square")
             storeExpectation.fulfill()
         }
@@ -71,9 +73,9 @@ class StoreTests: XCTestCase {
 
         let storeExpectation = expectation(description: "retrieve store expectation")
 
-        Store.byKey("unionSquare") { result in
+        Store.byKey(storeKey) { result in
             XCTAssert(result.isSuccess)
-            XCTAssertEqual(result.model!.key, "unionSquare")
+            XCTAssertEqual(result.model!.key, self.storeKey)
             XCTAssertEqual(result.model!.name!["en"], "Union Square")
             storeExpectation.fulfill()
         }
@@ -85,14 +87,14 @@ class StoreTests: XCTestCase {
 
         let storeExpectation = expectation(description: "cart store expectation")
 
-        Store.byKey("unionSquare") { result in
+        Store.byKey(storeKey) { result in
             let cartDraft = CartDraft(currency: "EUR", store: ResourceIdentifier(id: result.model!.id, typeId: .store))
 
             Cart.create(cartDraft) { result in
                 XCTAssert(result.isSuccess)
 
                 let cart = result.model!
-                XCTAssertEqual(cart.store!.key, "unionSquare")
+                XCTAssertEqual(cart.store!.key, self.storeKey)
 
                 Cart.delete(cart.id, version: cart.version) { result in
                     XCTAssert(result.isSuccess)
@@ -102,5 +104,101 @@ class StoreTests: XCTestCase {
         }
 
         waitForExpectations(timeout: 10, handler: nil)
+    }
+
+    func testStoreCartCreateAndRetrieve() {
+
+        let storeExpectation = expectation(description: "cart store expectation")
+
+        Store.byKey(storeKey) { result in
+            let cartDraft = CartDraft(currency: "EUR")
+
+            Cart.create(cartDraft, storeKey: self.storeKey) { result in
+                XCTAssert(result.isSuccess)
+
+                let cart = result.model!
+                XCTAssertEqual(cart.store!.key, self.storeKey)
+
+                Cart.byId(cart.id, storeKey: self.storeKey) { result in
+                    XCTAssert(result.isSuccess)
+
+                    XCTAssertEqual(result.model!.store!.key, self.storeKey)
+
+                    Cart.query(storeKey: self.storeKey, limit: 1) { result in
+                        XCTAssert(result.isSuccess)
+
+                        XCTAssertEqual(result.model!.results.first!.store!.key, self.storeKey)
+
+                        Cart.delete(cart.id, storeKey: self.storeKey, version: cart.version) { result in
+                            XCTAssert(result.isSuccess)
+                            storeExpectation.fulfill()
+                        }
+                    }
+                }
+            }
+        }
+
+        waitForExpectations(timeout: 10, handler: nil)
+    }
+
+    func testUpdateStoreCart() {
+
+        let storeExpectation = expectation(description: "cart store expectation")
+
+        Store.byKey(storeKey) { result in
+            let cartDraft = CartDraft(currency: "EUR")
+
+            Cart.create(cartDraft, storeKey: self.storeKey) { result in
+                XCTAssert(result.isSuccess)
+
+                let cart = result.model!
+                XCTAssertEqual(cart.store!.key, self.storeKey)
+
+                let updateActions = UpdateActions<CartUpdateAction>(version: cart.version, actions: [.setShippingAddress(address: Address(country: "DE"))])
+
+                Cart.update(cart.id, storeKey: self.storeKey, actions: updateActions) { result in
+                    XCTAssert(result.isSuccess)
+
+                    let cart = result.model!
+                    XCTAssertEqual(cart.store!.key, self.storeKey)
+                    XCTAssertEqual(cart.shippingAddress!.country, "DE")
+
+                    Cart.delete(cart.id, storeKey: self.storeKey, version: cart.version) { result in
+                        XCTAssert(result.isSuccess)
+                        storeExpectation.fulfill()
+                    }
+                }
+            }
+        }
+
+        waitForExpectations(timeout: 10, handler: nil)
+    }
+
+    func testUpdateNonStoreCart() {
+
+        let storeExpectation = expectation(description: "cart store expectation")
+
+        let cartDraft = CartDraft(currency: "EUR")
+
+        Cart.create(cartDraft) { result in
+            XCTAssert(result.isSuccess)
+
+            let cart = result.model!
+            XCTAssertNil(cart.store)
+
+            let updateActions = UpdateActions<CartUpdateAction>(version: cart.version, actions: [.setShippingAddress(address: Address(country: "DE"))])
+
+            Cart.update(cart.id, storeKey: self.storeKey, actions: updateActions) { result in
+                XCTAssert(result.isFailure)
+
+                if let error = result.errors?.first as? CTError, case .resourceNotFoundError(_) = error {
+                    XCTAssert(result.isFailure)
+                    XCTAssertEqual(result.statusCode, 404)
+                    storeExpectation.fulfill()
+                }
+            }
+        }
+
+        waitForExpectations(timeout: 100, handler: nil)
     }
 }


### PR DESCRIPTION
Added the following methods for the `Cart`:
- Get a Cart in a Store by ID
- Get Active Cart in a Store by ID
- Query Carts in a Store
- Create a Cart in a Store
- Update a Cart in a Store
- Delete a Cart in a Store

Added the following methods for the `Order`:
- Get Order in a Store by ID
- Query Orders in a Store by ID
- Create Order in a Store from a Cart