### PR TITLE
Closes #172 Support for external OAuth tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,11 @@ When an anonymous sessions ends with a sign up or a login, carts and orders are 
 
 ## External OAuth tokens
 
-Commercetools platform and the SDK provides the ability to use external OAuth tokens. In order to set a token from your app, use `Commercetools.externalToken` property. Once set, this token will be used for all platform requests from the SDK. In order to stop using external token, simply set this value to `nil`. To get more information on setting up and using external OAuth with commercetools platform, please refer to [this page](https://docs.commercetools.com/http-api-authorization#requesting-an-access-token-using-an-external-oauth-server-beta).
+Commercetools platform and the SDK provides the ability to use external OAuth tokens. In order to set a token from your app, use `Commercetools.externalToken` property. Once set, this token will be used for all platform requests from the SDK. In order to stop using external token, simply set this value to `nil`.
+
+When using an external token, it is important to handle expired and invalid token scenarios manually. Completion handler will provide a `CTError` with additional information, and the client should decide whether a token needs to be refreshed, or a recovery is not possible (e.g deleted account).
+
+To get more information on setting up and using external OAuth with commercetools platform, please refer to [this page](https://docs.commercetools.com/http-api-authorization#requesting-an-access-token-using-an-external-oauth-server-beta).
 
 ## Using the SDK in App Extensions
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Commercetools Swift SDK
 
-<img src="https://raw.githubusercontent.com/commercetools/press-kit/master/PNG/72DPI/CT%20logo%20horizontal%20RGB%2072dpi.png" height="80" />
+<img src="https://user-images.githubusercontent.com/14024032/60341258-32f83f80-99ae-11e9-86c0-1eb52f201a0d.png" height="80" />
 
 <p>
 <a href="https://travis-ci.org/commercetools/commercetools-ios-sdk" target="_blank">
@@ -155,6 +155,10 @@ Commercetools.obtainAnonymousToken(usingSession: true, anonymousId: "some-custom
 })
 ```
 When an anonymous sessions ends with a sign up or a login, carts and orders are migrated to the customer, and `CustomerSignInResult` is returned, providing access to both customer profile, and the currently active cart. For the login operation, you can define how to migrate line items from the currently active cart, by explicitly specifying one of two `AnonymousCartSignInMode` values: `.mergeWithExistingCustomerCart` or `.useAsNewActiveCustomerCart`.
+
+## External OAuth tokens
+
+Commercetools platform and the SDK provides the ability to use external OAuth tokens. In order to set a token from your app, use `Commercetools.externalToken` property. Once set, this token will be used for all platform requests from the SDK. In order to stop using external token, simply set this value to `nil`. To get more information on setting up and using external OAuth with commercetools platform, please refer to [this page](https://docs.commercetools.com/http-api-authorization#requesting-an-access-token-using-an-external-oauth-server-beta).
 
 ## Using the SDK in App Extensions
 

--- a/Source/AuthManager.swift
+++ b/Source/AuthManager.swift
@@ -23,6 +23,7 @@ open class AuthManager {
         case anonymousToken  = 1
         case plainToken      = 2
         case noToken         = 3
+        case externalToken   = 4
     }
 
     // MARK: - Properties
@@ -63,6 +64,41 @@ open class AuthManager {
         }
         set {
             tokenStore.refreshToken = newValue
+        }
+    }
+
+    /// The external token set by the client for External OAuth.
+    var externalToken: String? {
+        get {
+            guard OperationQueue.current != serialQueue else {
+                return tokenStore.externalToken
+            }
+            let semaphore = DispatchSemaphore(value: 0)
+            var token: String?
+            serialQueue.addOperation {
+                token = self.tokenStore.externalToken
+                semaphore.signal()
+            }
+            _ = semaphore.wait(timeout: .distantFuture)
+            return token
+        }
+        set {
+            serialQueue.addOperation {
+                self.clearAllTokens()
+                self.tokenStore.externalToken = newValue
+                guard newValue != nil else {
+                    Log.debug("Stopped using external token.\nGetting new anonymous access token.")
+                    self.token { _, error in
+                        if let error = error as? CTError {
+                            Log.error("Could not obtain auth token "
+                                    + (error.errorDescription ?? ""))
+                        }
+                    }
+                    return
+                }
+                Log.debug("Started using external token.")
+                self.state = .externalToken
+            }
         }
     }
 
@@ -116,14 +152,17 @@ open class AuthManager {
     }
 
     /// The serial queue used for processing token requests.
-    private let serialQueue = DispatchQueue(label: "com.commercetools.authQueue")
+    private let serialQueue = OperationQueue()
 
     // MARK: - Lifecycle
 
     /**
         Private initializer prevents `AuthManager` usage without using `sharedInstance`.
     */
-    private init() {}
+    private init() {
+        serialQueue.maxConcurrentOperationCount = 1
+        serialQueue.qualityOfService = .userInitiated
+    }
 
     // MARK: - Accessing token
 
@@ -140,7 +179,7 @@ open class AuthManager {
     func loginCustomer(username: String, password: String, completionHandler: @escaping (Error?) -> Void) {
         // Process all token requests using private serial queue to avoid issues with race conditions
         // when multiple credentials / login requests can lead auth manager in an unpredictable state
-        serialQueue.async(execute: {
+        serialQueue.addOperation {
             let semaphore = DispatchSemaphore(value: 0)
             if self.state != .plainToken {
                 self.logoutCustomer()
@@ -150,7 +189,7 @@ open class AuthManager {
                 semaphore.signal()
             })
             _ = semaphore.wait(timeout: DispatchTime.distantFuture)
-        })
+        }
     }
 
     /**
@@ -158,7 +197,9 @@ open class AuthManager {
         Most common use case for this method is user logout.
     */
     func logoutCustomer() {
-        clearAllTokens()
+        serialQueue.addOperation {
+            self.clearAllTokens()
+        }
 
         Log.debug("Getting new anonymous access token after user logout")
         token { _, error in
@@ -182,14 +223,14 @@ open class AuthManager {
     open func obtainAnonymousToken(usingSession: Bool, anonymousId: String? = nil, completionHandler: @escaping (Error?) -> Void) {
         // Process session changes using private serial queue to avoid issues with race conditions
         // when switching between anonymous and plain modes.
-        serialQueue.async(execute: {
+        serialQueue.addOperation {
             self.anonymousId = anonymousId
             self.usingAnonymousSession = usingSession
             self.clearAllTokens()
             self.token { _, error in
                 completionHandler(error)
             }
-        })
+        }
     }
 
     /**
@@ -203,14 +244,14 @@ open class AuthManager {
     func token(_ completionHandler: @escaping (String?, Error?) -> Void) {
         // Process all token requests using private serial queue to avoid issues with race conditions
         // when multiple credentials / login requests can lead auth manager in an unpredictable state
-        serialQueue.async(execute: {
+        serialQueue.addOperation {
             let semaphore = DispatchSemaphore(value: 0)
             self.processTokenRequest { token, error in
                 completionHandler(token, error)
                 semaphore.signal()
             }
             _ = semaphore.wait(timeout: DispatchTime.distantFuture)
-        })
+        }
     }
 
     /**
@@ -239,7 +280,7 @@ open class AuthManager {
         - parameter completionHandler:  The code to be executed once the token fetching completes.
     */
     func recoverFromInvalidTokenError(_ completionHandler: @escaping (String?, Error?) -> Void) {
-        serialQueue.async(execute: {
+        serialQueue.addOperation {
             guard self.accessToken != nil else {
                 self.clearAllTokens()
                 return
@@ -250,14 +291,17 @@ open class AuthManager {
             self.state = .noToken
             Log.debug("Removing access token, trying to recover from .invalidToken error")
             self.token(completionHandler)
-        })
+        }
     }
 
     // MARK: - Retrieving tokens from the auth API
 
     private func processTokenRequest(_ completionHandler: @escaping (String?, Error?) -> Void) {
         if let config = Config.currentConfig, config.validate() {
-            if let accessToken = accessToken, let tokenValidDate = tokenValidDate, tokenValidDate.compare(Date()) == .orderedDescending {
+            if let externalToken = externalToken, state == .externalToken {
+                completionHandler(externalToken, nil)
+
+            } else if let accessToken = accessToken, let tokenValidDate = tokenValidDate, tokenValidDate.compare(Date()) == .orderedDescending {
                 if refreshToken == nil {
                     self.state = .plainToken
                 }
@@ -341,6 +385,7 @@ open class AuthManager {
     private func clearAllTokens() {
         accessToken = nil
         refreshToken = nil
+        externalToken = nil
         tokenValidDate = nil
         state = .noToken
     }

--- a/Source/Commercetools.swift
+++ b/Source/Commercetools.swift
@@ -46,6 +46,16 @@ public var authState: AuthManager.TokenState {
     return AuthManager.sharedInstance.state
 }
 
+/// The external token to be used for all commercetools requests. To stop using external OAuth, set this property to `nil`.
+public var externalToken: String? {
+    get {
+        return AuthManager.sharedInstance.externalToken
+    }
+    set {
+        AuthManager.sharedInstance.externalToken = newValue
+    }
+}
+
 // MARK: - Project settings
 
 public struct Project: Endpoint, Codable {
@@ -172,15 +182,6 @@ public func signUpCustomer(_ profile: Data, result: @escaping (Result<CustomerSi
 */
 public func logoutCustomer() {
     AuthManager.sharedInstance.logoutCustomer()
-}
-
-public var externalToken: String? {
-    get {
-        return AuthManager.sharedInstance.externalToken
-    }
-    set {
-        AuthManager.sharedInstance.externalToken = newValue
-    }
 }
 
 /**

--- a/Source/Commercetools.swift
+++ b/Source/Commercetools.swift
@@ -174,6 +174,15 @@ public func logoutCustomer() {
     AuthManager.sharedInstance.logoutCustomer()
 }
 
+public var externalToken: String? {
+    get {
+        return AuthManager.sharedInstance.externalToken
+    }
+    set {
+        AuthManager.sharedInstance.externalToken = newValue
+    }
+}
+
 /**
     This method should be used to override `anonymousSession` Bool parameter from the configuration and get new tokens.
     Once this method is invoked, any previously logged in user will be logged out. In case there was an anonymous

--- a/Source/Commercetools.swift
+++ b/Source/Commercetools.swift
@@ -107,6 +107,9 @@ public struct Project: Endpoint, Codable {
 */
 public func loginCustomer(username: String, password: String, activeCartSignInMode: AnonymousCartSignInMode? = nil,
                           result: @escaping (Result<CustomerSignInResult>) -> Void) {
+    guard authState != .externalToken else {
+        fatalError("Customer login using external OAuth is not currently implemented.")
+    }
     if authState == .customerToken {
         logoutCustomer()
     }
@@ -159,6 +162,9 @@ public func signUpCustomer(_ profile: [String: Any], result: @escaping (Result<C
 }
 
 public func signUpCustomer(_ profile: Data, result: @escaping (Result<CustomerSignInResult>) -> Void) {
+    guard authState != .externalToken else {
+        fatalError("Customer sign up using external OAuth is not currently implemented.")
+    }
     Customer.signUp(profile, result: { signUpResult in
         if signUpResult.isFailure {
             result(signUpResult)

--- a/Tests/AuthManagerTests.swift
+++ b/Tests/AuthManagerTests.swift
@@ -357,4 +357,36 @@ class AuthManagerTests: XCTestCase {
 
         waitForExpectations(timeout: 10, handler: nil)
     }
+
+    func testExternalToken() {
+        setupTestConfiguration()
+
+        let tokenExpectation = expectation(description: "token expectation")
+
+        let authManager = AuthManager.sharedInstance
+
+        var oldToken: String?
+        authManager.token { token, error in oldToken = token }
+
+        let externalToken = UUID().uuidString
+        authManager.externalToken = externalToken
+
+        authManager.token { token, error in
+            XCTAssertNil(error)
+            XCTAssertEqual(token, externalToken)
+            XCTAssertEqual(authManager.state, .externalToken)
+        }
+
+        authManager.externalToken = nil
+
+        authManager.token { token, error in
+            XCTAssertNil(error)
+            XCTAssertNotEqual(token, externalToken)
+            XCTAssertNotEqual(token, oldToken)
+            XCTAssertEqual(authManager.state, .anonymousToken)
+            tokenExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 10, handler: nil)
+    }
 }

--- a/Tests/PlatformEndpoints/StoreTests.swift
+++ b/Tests/PlatformEndpoints/StoreTests.swift
@@ -25,7 +25,7 @@ class StoreTests: XCTestCase {
         static let path = "in-store/key=unionSquare/carts"
     }
 
-    private var storeId = "aa3b9e48-638c-460f-85c2-9c1162b3c3da"//: String!
+    private var storeId: String!
 
     private let storeKey = "unionSquare"
 

--- a/Tests/XCTestCase+Configuration.swift
+++ b/Tests/XCTestCase+Configuration.swift
@@ -38,6 +38,7 @@ extension XCTestCase {
         let tokenStore = authManager.tokenStore
         tokenStore.accessToken = nil
         tokenStore.refreshToken = nil
+        tokenStore.externalToken = nil
         tokenStore.tokenValidDate = nil
         tokenStore.tokenState = nil
     }


### PR DESCRIPTION
- [x] Add support for setting an external token by the client.
- [x] Auth manager tests.
- [x] Add `fatalError` to `loginCustomer` and `signUpCustomer` when using external OAuth.
- [x] Add external OAuth to readme.