### PR TITLE
Closes #174 Support for external user ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ When using an external token, it is important to handle expired and invalid toke
 
 To get more information on setting up and using external OAuth with commercetools platform, please refer to [this page](https://docs.commercetools.com/http-api-authorization#requesting-an-access-token-using-an-external-oauth-server-beta).
 
+## Tracking changes using external user ID
+
+It is possible to track changes initiated by a specific customer’s actions by setting value for `X-External-User-ID` header when performing create / update actions. In order to set an external user ID, use `Commercetools.externalUserId` property. Once set, this header will be included in all subsequent requests to commercetools API. The client should make sure there is no personally identifying information included in the `externalUserId` value. In order to remove the `X-External-User-ID` header from subsequent requests, set the `externalUserId` property to `nil`.
+
 ## Using the SDK in App Extensions
 
 If your app has extensions, and you want to use Commercetools SDK in those extensions, we recommend enabling keychain sharing. By allowing keychain sharing, and setting the appropriate access group name in the configuration `.plist`, the SDK will save all tokens in the shared keychain. Be sure to include _App ID Prefix / Team ID_ in the access group name.

--- a/Source/AuthManager.swift
+++ b/Source/AuthManager.swift
@@ -268,8 +268,8 @@ open class AuthManager {
         serialQueue.addOperation {
             let semaphore = DispatchSemaphore(value: 0)
             self.processTokenRequest { token, error in
-                completionHandler(token, error)
                 semaphore.signal()
+                completionHandler(token, error)
             }
             _ = semaphore.wait(timeout: DispatchTime.distantFuture)
         }

--- a/Source/Commercetools.swift
+++ b/Source/Commercetools.swift
@@ -56,6 +56,16 @@ public var externalToken: String? {
     }
 }
 
+/// The external user ID, passed using X-External-User-ID header. To remove external user ID from subsequent requests, set this property to `nil`.
+public var externalUserId: String? {
+    get {
+        return AuthManager.sharedInstance.externalUserId
+    }
+    set {
+        AuthManager.sharedInstance.externalUserId = newValue
+    }
+}
+
 // MARK: - Project settings
 
 public struct Project: Endpoint, Codable {

--- a/Source/Endpoint.swift
+++ b/Source/Endpoint.swift
@@ -80,6 +80,9 @@ public extension Endpoint {
     static func headers(_ token: String) -> [String: String] {
         var headers = defaultHeaders
         headers["Authorization"] = "Bearer \(token)"
+        if let externalUserId = AuthManager.sharedInstance.externalUserId {
+            headers["X-External-User-ID"] = externalUserId
+        }
         return headers
     }
 

--- a/Tests/Core/CreateEndpointTests.swift
+++ b/Tests/Core/CreateEndpointTests.swift
@@ -67,5 +67,23 @@ class CreateEndpointTests: XCTestCase {
 
         waitForExpectations(timeout: 10, handler: nil)
     }
-    
+
+    func testExternalUserIdHeader() {
+
+        let createdByHeaderExpectation = expectation(description: "created by header expectation")
+
+        let externalUserId = UUID().uuidString
+        AuthManager.sharedInstance.externalUserId = externalUserId
+
+        TestCart.create(["currency": "EUR"], result: { result in
+            if let cart = result.model {
+                XCTAssert(result.isSuccess)
+                XCTAssertEqual(cart.createdBy!.externalUserId, externalUserId)
+                XCTAssertEqual(cart.lastModifiedBy!.externalUserId, externalUserId)
+                createdByHeaderExpectation.fulfill()
+            }
+        })
+
+        waitForExpectations(timeout: 10, handler: nil)
+    }
 }

--- a/Tests/XCTestCase+Configuration.swift
+++ b/Tests/XCTestCase+Configuration.swift
@@ -41,6 +41,7 @@ extension XCTestCase {
         tokenStore.externalToken = nil
         tokenStore.tokenValidDate = nil
         tokenStore.tokenState = nil
+        tokenStore.externalUserId = nil
     }
 
 }


### PR DESCRIPTION
- [x] Exposed `Commercetools.externalUserId` property to SDK clients;
- [x] Tested `createdBy.externalUserId` & `lastModifiedBy!.externalUserId` when using `X-External-User-ID`;
- [x] Updated readme.

@cneijenhuis if you get a chance, feel free to have a glance.