### PR TITLE
Closes #177 Support for Customer Profile in a Specific Store

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ language: objective-c
 before_install:
   - gem install xcpretty --no-document --quiet
 
-osx_image: xcode10.2
+osx_image: xcode11.1
 
-xcode_sdk: iphonesimulator12.2
+xcode_sdk: iphonesimulator13.1
 
 script:
   - set -o pipefail
   - xcodebuild -showsdks
-  - xcodebuild -project Commercetools.xcodeproj -scheme "Commercetools iOS" -destination "platform=iOS Simulator,name=iPhone 6" test | xcpretty -c;
+  - xcodebuild -project Commercetools.xcodeproj -scheme "Commercetools iOS" -destination "platform=iOS Simulator,name=iPhone 8" test | xcpretty -c;

--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ Category.byId("cddddddd-ffff-4b44-b5b0-004e7d4bc2dd", result: { result in
 Customer endpoint offers you several possible actions to use from your iOS app:
 - Retrieve user profile (user must be logged in)
 ```swift
+// Optionally set `storeKey` for customers registered in a specific store.
 Customer.profile { result in
     if let profile = result.model, let firstName = profile.firstName,
             let lastName = profile.lastName, result.isSuccess {
@@ -350,6 +351,7 @@ var customerDraft = CustomerDraft()
 customerDraft.email = "new.swift.sdk.test.user@commercetools.com"
 customerDraft.password = "password"
 
+// Optionally set `storeKey` to sign up the customer in that store.
 Commercetools.signUpCustomer(customerDraft, result: { result in
     if let customer = result.model?.customer, let version = customer.version, result.isSuccess {
         // User has been successfully signed up.
@@ -364,6 +366,7 @@ var options = SetFirstNameOptions()
 options.firstName = "newName"
 
 let updateActions = UpdateActions<CustomerUpdateAction>(version: version, actions: [.setFirstName(options: options)])
+// Optionally set `storeKey` for customers registered in a specific store.
 Customer.update(actions: updateActions, result: { result in
     if let customer = result.model, let version = customer.version, result.isSuccess {
     	// User profile successfully updated
@@ -372,6 +375,7 @@ Customer.update(actions: updateActions, result: { result in
 ```
 - Delete customer account (user must be logged in)
 ```swift
+// Optionally set `storeKey` for customers registered in a specific store.
 Customer.delete(version: version, result: { result in
     if let customer = result.model, result.isSuccess {
         // Customer was successfully deleted
@@ -382,6 +386,7 @@ Customer.delete(version: version, result: { result in
 ```swift
 let  version = 1 // Set the appropriate current version
 
+// Optionally set `storeKey` for customers registered in a specific store.
 Customer.changePassword(currentPassword: "password", newPassword: "newPassword", version: version, result: { result in
     if let customer = result.model, result.isSuccess {
     	// Password has been changed, and now AuthManager has automatically obtained new access token
@@ -392,6 +397,7 @@ Customer.changePassword(currentPassword: "password", newPassword: "newPassword",
 ```swift
 let token = "" // Usually this token is retrieved from the password reset link, in case your app does support universal links
 
+// Optionally set `storeKey` for customers registered in a specific store.
 Customer.resetPassword(token: token, newPassword: "password", result: { result in
     if let customer = result.model, let email = customer.email, result.isSuccess {
         // Password has been successfully reset, now would be a good time to present the login screen
@@ -402,6 +408,7 @@ Customer.resetPassword(token: token, newPassword: "password", result: { result i
 ```swift
 let token = "" // Usually this token is retrieved from the activation link, in case your app does support universal links
 
+// Optionally set `storeKey` for customers registered in a specific store.
 Customer.verifyEmail(token: token, result: { result in
     if let customer = result.model, let email = customer.email, result.isSuccess {
         // Email has been successfully verified, probably show UIAlertController with this info

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <img src="https://img.shields.io/cocoapods/v/Commercetools.svg">
 </a>
 <a href="https://developer.apple.com/swift/" target="_blank">
-<img src="https://img.shields.io/badge/Swift-5-orange.svg?style=flat" alt="Swift 5">
+<img src="https://img.shields.io/badge/Swift-5.1-orange.svg?style=flat" alt="Swift 5.1">
 </a>
 <a href="https://developer.apple.com/swift/" target="_blank">
 <img src="https://img.shields.io/badge/Platforms-iOS%20%7C%20macOS%20%7C%20watchOS%20%7C%20tvOS%20%7C%20Linux-4E4E4E.svg?colorA=EF5138" alt="Platforms iOS | macOS | watchOS | tvOS | Linux">
@@ -29,7 +29,7 @@
 
 - iOS 10.0+ / macOS 10.10+ / tvOS 9.0+ / watchOS 2.0+
 - Xcode 9.0+
-- Swift 5.0+
+- Swift 5.1+
 
 ### CocoaPods
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ The Commercetools SDK uses a `.plist` configuration file named `CommercetoolsCon
     <true/>
     <key>emergencyContactInfo</key>
     <string>you@yourdomain.com</string>
+    <key>storeKey</key>
+    <string>global-store-key</string>
 </dict>
 </plist> 
 ```
@@ -170,6 +172,8 @@ Commercetools.loginCustomer(username, password: password, storeKey: "store-key",
     }
 })
 ```
+
+If the app is only going to work with a specific store, it is recommended that the global store key is set as a part of the configuration `.plist` file. That way, the SDK will use the `storeKey` for all subsequent requests, for store-specific endpoints.
 
 ## External OAuth tokens
 

--- a/Source/AuthManager.swift
+++ b/Source/AuthManager.swift
@@ -167,7 +167,7 @@ open class AuthManager {
         - parameter storeKey:           For customers registered in a specific store, a store key must be specified.
         - parameter completionHandler:  The code to be executed once the token fetching completes.
     */
-    func loginCustomer(username: String, password: String, storeKey: String?, completionHandler: @escaping (Error?) -> Void) {
+    func loginCustomer(username: String, password: String, storeKey: String? = nil, completionHandler: @escaping (Error?) -> Void) {
         // Process all token requests using private serial queue to avoid issues with race conditions
         // when multiple credentials / login requests can lead auth manager in an unpredictable state
         serialQueue.addOperation {

--- a/Source/AuthManager.swift
+++ b/Source/AuthManager.swift
@@ -167,7 +167,7 @@ open class AuthManager {
         - parameter storeKey:           For customers registered in a specific store, a store key must be specified.
         - parameter completionHandler:  The code to be executed once the token fetching completes.
     */
-    func loginCustomer(username: String, password: String, storeKey: String? = nil, completionHandler: @escaping (Error?) -> Void) {
+    func loginCustomer(username: String, password: String, storeKey: String?, completionHandler: @escaping (Error?) -> Void) {
         // Process all token requests using private serial queue to avoid issues with race conditions
         // when multiple credentials / login requests can lead auth manager in an unpredictable state
         serialQueue.addOperation {

--- a/Source/Cart.swift
+++ b/Source/Cart.swift
@@ -15,6 +15,129 @@ public struct Cart: QueryEndpoint, ByIdEndpoint, CreateEndpoint, UpdateEndpoint,
 
     public static let path = "me/carts"
 
+    // MARK: - Basic cart methods
+
+
+    /**
+        Queries for carts.
+
+        - parameter predicate:                An optional array of predicates used for querying for carts.
+        - parameter sort:                     An optional array of sort options used for sorting the results.
+        - parameter expansion:                An optional array of expansion property names.
+        - parameter limit:                    An optional parameter to limit the number of returned results.
+        - parameter offset:                   An optional parameter to set the offset of the first returned result.
+        - parameter result:                   The code to be executed after processing the response, providing model
+                                              instance in case of a successful result.
+    */
+    public static func query(predicates: [String]? = nil, sort: [String]? = nil, expansion: [String]? = nil, limit: UInt? = nil, offset: UInt? = nil, result: @escaping (Result<QueryResponse<ResponseType>>) -> Void) {
+        if let storeKey = Config.currentConfig?.storeKey {
+            query(storeKey: storeKey, predicates: predicates, sort: sort, expansion: expansion, limit: limit, offset: offset, result: result)
+        } else {
+            query(predicates: predicates, sort: sort, expansion: expansion, limit: limit, offset: offset, path: Self.path, result: result)
+        }
+    }
+
+
+    /**
+        Retrieves a cart by UUID.
+
+        - parameter id:                       Unique ID of the cart to be retrieved.
+        - parameter expansion:                An optional array of expansion property names.
+        - parameter result:                   The code to be executed after processing the response, providing model
+                                              instance in case of a successful result.
+    */
+    public static func byId(_ id: String, expansion: [String]?, result: @escaping (Result<ResponseType>) -> Void) {
+        if let storeKey = Config.currentConfig?.storeKey {
+            byId(id, storeKey: storeKey, expansion: expansion, result: result)
+        } else {
+            byId(id, expansion: expansion, path: Self.path, result: result)
+        }
+    }
+
+    /**
+        Creates a new cart.
+
+        - parameter object:                   Dictionary representation of the cart draft to be created.
+        - parameter expansion:                An optional array of expansion property names.
+        - parameter result:                   The code to be executed after processing the response.
+    */
+    public static func create(_ object: [String: Any]?, expansion: [String]?, result: @escaping (Result<ResponseType>) -> Void) {
+        if let storeKey = Config.currentConfig?.storeKey {
+            create(object, storeKey: storeKey, expansion: expansion, result: result)
+        } else {
+            create(object, expansion: expansion, path: Self.path, result: result)
+        }
+    }
+
+    /**
+        Creates a new cart.
+
+        - parameter object:                   CartDraft object to be created.
+        - parameter expansion:                An optional array of expansion property names.
+        - parameter result:                   The code to be executed after processing the response.
+    */
+    public static func create(_ object: RequestDraft, expansion: [String]?, result: @escaping (Result<ResponseType>) -> Void) {
+        if let storeKey = Config.currentConfig?.storeKey {
+            create(object, storeKey: storeKey, expansion: expansion, result: result)
+        } else {
+            create(object, expansion: expansion, path: Self.path, result: result)
+        }
+    }
+
+    /**
+        Updates a cart by UUID.
+
+        - parameter id:                       Unique ID of the cart to be updated.
+        - parameter actions:                  `UpdateActions`instance, containing correct version and update actions.
+        - parameter expansion:                An optional array of expansion property names.
+        - parameter result:                   The code to be executed after processing the response, providing model
+                                              instance in case of a successful result.
+    */
+    public static func update(_ id: String, actions: UpdateActions<UpdateAction>, expansion: [String]?, result: @escaping (Result<ResponseType>) -> Void) {
+        if let storeKey = Config.currentConfig?.storeKey {
+            update(id, storeKey: storeKey, actions: actions, expansion: expansion, result: result)
+        } else {
+            update(id, actions: actions, expansion: expansion, path: Self.path, result: result)
+        }
+
+    }
+
+    /**
+        Updates a cart by UUID.
+
+        - parameter id:                       Unique ID of the cart to be updated.
+        - parameter version:                  Version of the object (for optimistic concurrency control).
+        - parameter actions:                  An array of actions to be executed, in dictionary representation.
+        - parameter expansion:                An optional array of expansion property names.
+        - parameter result:                   The code to be executed after processing the response, providing model
+                                              instance in case of a successful result.
+    */
+    public static func update(_ id: String, version: UInt, actions: [[String: Any]], expansion: [String]?, result: @escaping (Result<ResponseType>) -> Void) {
+        if let storeKey = Config.currentConfig?.storeKey {
+            update(id, storeKey: storeKey, version: version, actions: actions, expansion: expansion, result: result)
+        } else {
+            update(id, version: version, actions: actions, expansion: expansion, path: Self.path, result: result)
+        }
+    }
+
+
+    /**
+        Deletes a cart by UUID from a store specified by key.
+
+        - parameter id:                       Unique ID of the cart to be deleted.
+        - parameter version:                  Version of the cart (for optimistic concurrency control).
+        - parameter expansion:                An optional array of expansion property names.
+        - parameter result:                   The code to be executed after processing the response, providing model
+                                              instance in case of a successful result.
+    */
+    public static func delete(_ id: String, version: UInt, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
+        if let storeKey = Config.currentConfig?.storeKey {
+            delete(id, storeKey: storeKey, version: version, expansion: expansion, result: result)
+        } else {
+            delete(id, version: version, expansion: expansion, path: Self.path, result: result)
+        }
+    }
+
     // MARK: - Active cart
 
     /**
@@ -46,6 +169,10 @@ public struct Cart: QueryEndpoint, ByIdEndpoint, CreateEndpoint, UpdateEndpoint,
                                               instance in case of a successful result.
      */
     public static func active(storeKey: String, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
+        guard Config.currentConfig?.storeKey == nil else {
+            active(storeKey: Config.currentConfig!.storeKey!, expansion: expansion, result: result)
+            return
+        }
         requestWithTokenAndPath(relativePath: "in-store/key=\(storeKey)/me/active-cart", result: result) { token, path in
             let fullPath = pathWithExpansion(path, expansion: expansion)
             let request = self.request(url: fullPath, headers: self.headers(token))
@@ -112,7 +239,7 @@ public struct Cart: QueryEndpoint, ByIdEndpoint, CreateEndpoint, UpdateEndpoint,
     /**
         Updates a cart with the specified UUID in a store.
 
-        - parameter id:                       Unique ID of the cart to be deleted.
+        - parameter id:                       Unique ID of the cart to be updated.
         - parameter storeKey:                 Key referencing the store used for the update.
         - parameter actions:                  `UpdateActions`instance, containing correct version and update actions.
         - parameter expansion:                An optional array of expansion property names.
@@ -126,7 +253,7 @@ public struct Cart: QueryEndpoint, ByIdEndpoint, CreateEndpoint, UpdateEndpoint,
     /**
         Updates a cart with the specified UUID in a store.
 
-        - parameter id:                       Unique ID of the cart to be deleted.
+        - parameter id:                       Unique ID of the cart to be updated.
         - parameter storeKey:                 Key referencing the store used for the update.
         - parameter version:                  Version of the cart (for optimistic concurrency control).
         - parameter actions:                  An array of actions to be executed, in dictionary representation.

--- a/Source/Config.swift
+++ b/Source/Config.swift
@@ -53,6 +53,9 @@ public class Config {
     /// Emergency contact info which is passed to the platform.
     public private(set) var emergencyContactInfo: String?
 
+    /// If set, the `storeKey` is added to all store-specific requests (currently `Customer`, `Cart`, and `Order` endpoints are supported).
+    public private(set) var storeKey: String?
+
     /**
         The current app authorization server URL.
 
@@ -145,6 +148,7 @@ public class Config {
         shareWatchSession = config["shareWatchSession"] as? Bool ?? false
         keychainAccessGroupName = config["keychainAccessGroupName"] as? String
         emergencyContactInfo = config["emergencyContactInfo"] as? String
+        storeKey = config["storeKey"] as? String
 
         if let apiUrl = apiUrl, !apiUrl.hasSuffix("/") {
             self.apiUrl = apiUrl + "/"
@@ -204,7 +208,11 @@ public class Config {
             machineLearningApiUrl = "https://ml-eu.europe-west1.gcp.commercetools.com/"
         }
 
-        if (!valid) {
+        if let storeKey = storeKey {
+            Log.debug("Store key: \"\(storeKey)\" has been set and will be used globally with all subsequent requests on supported endpoints.")
+        }
+
+        if !valid {
             Log.error("Please go to admin.sphere.io, 'Developers' section, 'API clients' tab.")
         }
 

--- a/Source/Customer.swift
+++ b/Source/Customer.swift
@@ -187,7 +187,8 @@ public class Customer: Endpoint, Codable {
                                               json: [String: Any]? = nil, result: @escaping (Result<T>) -> Void) {
 
         requestWithTokenAndPath(result: result) { token, path in
-            let fullPath = pathWithExpansion(storeKeyPathParameter != nil ? "\(path)in-store/key=\(storeKeyPathParameter!)/me/\(basePath ?? "")" : "\(path)me/\(basePath ?? "")", expansion: expansion)
+            let storeKey = storeKeyPathParameter ?? Config.currentConfig?.storeKey
+            let fullPath = pathWithExpansion(storeKey != nil ? "\(path)in-store/key=\(storeKey!)/me/\(basePath ?? "")" : "\(path)me/\(basePath ?? "")", expansion: expansion)
             let request = self.request(url: fullPath, method: method, urlParameters: urlParameters,
                                        json: json, headers: self.headers(token))
 

--- a/Source/Endpoint.swift
+++ b/Source/Endpoint.swift
@@ -38,6 +38,7 @@ public extension Endpoint {
     /// The full path used to form requests for endpoints.
     static func fullPath(relativePath: String = Self.path) -> String? {
         if let config = Config.currentConfig, let apiUrl = config.apiUrl, let projectKey = config.projectKey {
+            guard !relativePath.isEmpty else { return "\(apiUrl)\(projectKey)/" }
             var normalizedPath = relativePath
             if normalizedPath.hasPrefix("/") {
                 normalizedPath.remove(at: String.Index(encodedOffset: 0))

--- a/Source/Order.swift
+++ b/Source/Order.swift
@@ -55,6 +55,73 @@ public struct Order: QueryEndpoint, ByIdEndpoint, CreateEndpoint, Codable {
     public let origin: CartOrigin
     public let itemShippingAddresses: [Address]
 
+    // MARK: - Basic order methods
+
+    /**
+        Queries for orders.
+
+        - parameter predicate:                An optional array of predicates used for querying for orders.
+        - parameter sort:                     An optional array of sort options used for sorting the results.
+        - parameter expansion:                An optional array of expansion property names.
+        - parameter limit:                    An optional parameter to limit the number of returned results.
+        - parameter offset:                   An optional parameter to set the offset of the first returned result.
+        - parameter result:                   The code to be executed after processing the response, providing model
+                                              instance in case of a successful result.
+    */
+    public static func query(predicates: [String]? = nil, sort: [String]? = nil, expansion: [String]? = nil, limit: UInt? = nil, offset: UInt? = nil, result: @escaping (Result<QueryResponse<ResponseType>>) -> Void) {
+        if let storeKey = Config.currentConfig?.storeKey {
+            query(storeKey: storeKey, predicates: predicates, sort: sort, expansion: expansion, limit: limit, offset: offset, result: result)
+        } else {
+            query(predicates: predicates, sort: sort, expansion: expansion, limit: limit, offset: offset, path: Self.path, result: result)
+        }
+    }
+
+    /**
+        Retrieves an order by UUID.
+
+        - parameter id:                       Unique ID of the order to be retrieved.
+        - parameter expansion:                An optional array of expansion property names.
+        - parameter result:                   The code to be executed after processing the response, providing model
+                                              instance in case of a successful result.
+    */
+    public static func byId(_ id: String, expansion: [String]? = nil, result: @escaping (Result<ResponseType>) -> Void) {
+        if let storeKey = Config.currentConfig?.storeKey {
+            byId(id, storeKey: storeKey, expansion: expansion, result: result)
+        } else {
+            byId(id, expansion: expansion, path: Self.path, result: result)
+        }
+    }
+
+    /**
+        Creates a new order.
+
+        - parameter object:                   Dictionary representation of the order draft to be created.
+        - parameter expansion:                An optional array of expansion property names.
+        - parameter result:                   The code to be executed after processing the response.
+    */
+    public static func create(_ object: [String: Any]?, expansion: [String]?, result: @escaping (Result<ResponseType>) -> Void) {
+        if let storeKey = Config.currentConfig?.storeKey {
+            create(object, storeKey: storeKey, expansion: expansion, result: result)
+        } else {
+            create(object, expansion: expansion, path: Self.path, result: result)
+        }
+    }
+
+    /**
+        Creates a new order.
+
+        - parameter object:                   OrderDraft object to be created.
+        - parameter expansion:                An optional array of expansion property names.
+        - parameter result:                   The code to be executed after processing the response.
+    */
+    public static func create(_ object: RequestDraft, expansion: [String]?, result: @escaping (Result<ResponseType>) -> Void) {
+        if let storeKey = Config.currentConfig?.storeKey {
+            create(object, storeKey: storeKey, expansion: expansion, result: result)
+        } else {
+            create(object, expansion: expansion, path: Self.path, result: result)
+        }
+    }
+
     // MARK: - In store order
 
     /**
@@ -87,7 +154,7 @@ public struct Order: QueryEndpoint, ByIdEndpoint, CreateEndpoint, Codable {
     }
 
     /**
-        Creates new order in a store specified by key.
+        Creates a new order in a store specified by key.
 
         - parameter object:                   Dictionary representation of the order draft to be created.
         - parameter storeKey:                 Key referencing the store where the new order will be created.
@@ -99,7 +166,7 @@ public struct Order: QueryEndpoint, ByIdEndpoint, CreateEndpoint, Codable {
     }
 
     /**
-        Creates new order in a store specified by key.
+        Creates a new order in a store specified by key.
 
         - parameter object:                   OrderDraft to be created.
         - parameter storeKey:                 Key referencing the store where the new order will be created.

--- a/Source/UpdateEndpoint.swift
+++ b/Source/UpdateEndpoint.swift
@@ -16,7 +16,7 @@ public protocol UpdateEndpoint: Endpoint {
     /**
         Updates an object by UUID at the endpoint specified with `path` value.
 
-        - parameter id:                       Unique ID of the object to be deleted.
+        - parameter id:                       Unique ID of the object to be updated.
         - parameter actions:                  `UpdateActions`instance, containing correct version and update actions.
         - parameter expansion:                An optional array of expansion property names.
         - parameter result:                   The code to be executed after processing the response, providing model
@@ -27,7 +27,7 @@ public protocol UpdateEndpoint: Endpoint {
     /**
         Updates an object by UUID at the endpoint specified with `path` value.
 
-        - parameter id:                       Unique ID of the object to be deleted.
+        - parameter id:                       Unique ID of the object to be updated.
         - parameter version:                  Version of the object (for optimistic concurrency control).
         - parameter actions:                  An array of actions to be executed, in dictionary representation.
         - parameter expansion:                An optional array of expansion property names.

--- a/Tests/PlatformEndpoints/CustomerTests.swift
+++ b/Tests/PlatformEndpoints/CustomerTests.swift
@@ -67,9 +67,9 @@ class CustomerTests: XCTestCase {
         let createProfileExpectation = expectation(description: "create profile expectation")
         let deleteProfileExpectation = expectation(description: "delete profile expectation")
 
-        let signUpDraft = try! JSONSerialization.data(withJSONObject: ["email": username, "password": "password"], options: [])
+        let signUpDraft = ["email": username, "password": "password"]
 
-        Customer.signUp(signUpDraft, result: { result in
+        Customer.signUp(signUpDraft, storeKey: nil, result: { result in
             if let response = result.json, let customer = response["customer"] as? [String: Any],
                let email = customer["email"] as? String, let version = customer["version"] as? UInt {
                 XCTAssert(result.isSuccess)
@@ -139,10 +139,10 @@ class CustomerTests: XCTestCase {
                         XCTAssert(result.isSuccess)
                         XCTAssertEqual(profile.firstName, "newName")
                         XCTAssertEqual(profile.salutation, "salutation")
-                        
+
                         // Now revert back to the old values
                         let updateActions = UpdateActions<CustomerUpdateAction>(version: profile.version, actions: [.setFirstName(firstName: "Test"), .setSalutation(salutation: "")])
-                        
+
                         Customer.update(actions: updateActions, result: { result in
                             if let profile = result.model {
                                 XCTAssert(result.isSuccess)
@@ -164,9 +164,9 @@ class CustomerTests: XCTestCase {
 
         let createProfileExpectation = expectation(description: "create profile expectation")
 
-        let signUpDraft = try! JSONSerialization.data(withJSONObject: ["email": "swift.sdk.test.user2@commercetools.com", "password": "password"], options: [])
+        let signUpDraft = ["email": "swift.sdk.test.user2@commercetools.com", "password": "password"]
 
-        Customer.signUp(signUpDraft, result: { result in
+        Customer.signUp(signUpDraft, storeKey: nil, result: { result in
             if let error = result.errors?.first as? CTError, case .generalError(let reason) = error {
                 XCTAssert(result.isFailure)
                 XCTAssertEqual(reason?.message, "There is already an existing customer with the email '\"swift.sdk.test.user2@commercetools.com\"'.")
@@ -290,13 +290,13 @@ class CustomerTests: XCTestCase {
         // Obtain password reset token
         AuthManager.sharedInstance.token { token, error in
             guard let token = token, let path = TestCustomer.fullPath() else { return }
-            
+
             let customerResult: ((Commercetools.Result<NoMapping>) -> Void) = { result in
                 if let response = result.json, let token = response["value"] as? String, result.isSuccess {
-                    
+
                     // Now confirm reset password token with regular mobile client scope
                     self.setupTestConfiguration()
-                    
+
                     Customer.resetPassword(token: token, newPassword: "password", result: { result in
                         if let response = result.json, let email = response["email"] as? String {
                             XCTAssert(result.isSuccess)
@@ -337,15 +337,225 @@ class CustomerTests: XCTestCase {
             TestCustomer.query(predicates: ["email=\"\(username)\""], result: { result in
                 if let response = result.json, let results = response["results"] as? [[String: AnyObject]],
                         let id = results.first?["id"] as? String, result.isSuccess {
-                    
+
                     let customerResult: ((Commercetools.Result<NoMapping>) -> Void) = { result in
                         if let response = result.json, let token = response["value"] as? String, result.isSuccess {
-                            
+
                             // Confirm email verification token with regular mobile client scope
                             self.setupTestConfiguration()
                             AuthManager.sharedInstance.loginCustomer(username: username, password: password, completionHandler: { _ in})
-                            
+
                             Customer.verifyEmail(token: token, result: { result in
+                                if let response = result.json, let email = response["email"] as? String {
+                                    XCTAssert(result.isSuccess)
+                                    XCTAssertEqual(email, username)
+                                    verifyEmailExpectation.fulfill()
+                                }
+                            })
+                        }
+                    }
+
+                    // Now generate email activation token
+                    let request = TestCustomer.request(url: "\(path)email-token", method: .post, json: ["id": id, "ttlMinutes": 1], headers: TestCustomer.headers(token))
+
+                    TestCustomer.perform(request: request) { (response: Result<NoMapping>) in
+                        customerResult(response)
+                    }
+                }
+            })
+        }
+
+        waitForExpectations(timeout: 20, handler: nil)
+    }
+
+    func testRetrieveCustomerProfileInStore() {
+        setupTestConfiguration()
+
+        let retrieveProfileExpectation = expectation(description: "retrieve profile expectation")
+
+        let username = "swift.sdk.test.in.store.user@commercetools.com"
+        let password = "password"
+
+        AuthManager.sharedInstance.loginCustomer(username: username, password: password, storeKey: "in-store-customer-test", completionHandler: { _ in})
+
+        Customer.profile { result in
+            if let response = result.json {
+                XCTAssert(result.isSuccess)
+                XCTAssertNotNil(response["firstName"] as? String)
+                XCTAssertNotNil(response["lastName"] as? String)
+                retrieveProfileExpectation.fulfill()
+            }
+        }
+
+        waitForExpectations(timeout: 10, handler: nil)
+    }
+
+    func testCreateAndDeleteProfileInStore() {
+        setupTestConfiguration()
+
+        let username = "new.swift.sdk.test.user.in.store@commercetools.com"
+
+        let createProfileExpectation = expectation(description: "create profile expectation")
+        let deleteProfileExpectation = expectation(description: "delete profile expectation")
+
+        let customerDraft = CustomerDraft(email: username, password: "password")
+
+        Commercetools.signUpCustomer(customerDraft, storeKey: "in-store-customer-test", result: { result in
+            if let customer = result.model?.customer, customer.email == username, result.isSuccess {
+                XCTAssert(result.isSuccess)
+                XCTAssertEqual(customer.email, username)
+                createProfileExpectation.fulfill()
+
+                AuthManager.sharedInstance.loginCustomer(username: username, password: "password", storeKey: "in-store-customer-test") { _ in
+                    Customer.delete(version: customer.version, storeKey: "in-store-customer-test", result: { result in
+                        if let deletedCustomer = result.model {
+                            XCTAssert(result.isSuccess)
+                            XCTAssertEqual(deletedCustomer.email, username)
+                            deleteProfileExpectation.fulfill()
+                        }
+                    })
+                }
+            }
+        })
+
+        waitForExpectations(timeout: 10, handler: nil)
+    }
+
+    func testUpdateProfileInStore() {
+        setupTestConfiguration()
+
+        let updateProfileExpectation = expectation(description: "update profile expectation")
+
+        let username = "swift.sdk.test.in.store.user@commercetools.com"
+        let password = "password"
+
+        AuthManager.sharedInstance.loginCustomer(username: username, password: password, storeKey: "in-store-customer-test", completionHandler: { _ in})
+
+        Customer.profile(storeKey: "in-store-customer-test") { result in
+            if let profile = result.model, result.isSuccess {
+                let updateActions = UpdateActions<CustomerUpdateAction>(version: profile.version, actions: [.setFirstName(firstName: "newName"), .setSalutation(salutation: "salutation")])
+                Customer.update(actions: updateActions, storeKey: "in-store-customer-test", result: { result in
+                    if let profile = result.model {
+                        XCTAssert(result.isSuccess)
+                        XCTAssertEqual(profile.firstName, "newName")
+                        XCTAssertEqual(profile.salutation, "salutation")
+
+                        // Now revert back to the old values
+                        let updateActions = UpdateActions<CustomerUpdateAction>(version: profile.version, actions: [.setFirstName(firstName: "Test"), .setSalutation(salutation: "")])
+
+                        Customer.update(actions: updateActions, storeKey: "in-store-customer-test", result: { result in
+                            if let profile = result.model {
+                                XCTAssert(result.isSuccess)
+                                XCTAssertEqual(profile.firstName, "Test")
+                                XCTAssertEqual(profile.salutation, "")
+                                updateProfileExpectation.fulfill()
+                            }
+                        })
+                    }
+                })
+            }
+        }
+
+        waitForExpectations(timeout: 10, handler: nil)
+    }
+
+    func testChangePasswordInStore() {
+        setupTestConfiguration()
+
+        let changePasswordExpectation = expectation(description: "change password expectation")
+
+        let username = "swift.sdk.test.in.store.user@commercetools.com"
+        let password = "password"
+
+        AuthManager.sharedInstance.loginCustomer(username: username, password: password, storeKey: "in-store-customer-test", completionHandler: { _ in})
+
+        Customer.profile(storeKey: "in-store-customer-test") { result in
+            if let response = result.json, let version = response["version"] as? UInt, result.isSuccess {
+
+                Customer.changePassword(currentPassword: password, newPassword: "newPassword", version: version, storeKey: "in-store-customer-test", result: { result in
+                    if let response = result.json, let version = response["version"] as? UInt, result.isSuccess {
+
+                        // Now revert the password change
+                        Customer.changePassword(currentPassword: "newPassword", newPassword: password, version: version, storeKey: "in-store-customer-test", result: { result in
+                            XCTAssert(result.isSuccess)
+                            changePasswordExpectation.fulfill()
+                        })
+                    }
+                })
+            }
+        }
+
+        waitForExpectations(timeout: 10, handler: nil)
+    }
+
+    func testResetPasswordInStore() {
+
+        let resetPasswordExpectation = expectation(description: "reset password expectation")
+
+        let username = "swift.sdk.test.in.store.user@commercetools.com"
+
+        // For generating password reset token we need higher privileges
+        setupProjectManagementConfiguration()
+
+        // Obtain password reset token
+        AuthManager.sharedInstance.token { token, error in
+            guard let token = token, let path = TestCustomer.fullPath() else { return }
+
+            let customerResult: ((Commercetools.Result<NoMapping>) -> Void) = { result in
+                if let response = result.json, let token = response["value"] as? String, result.isSuccess {
+
+                    // Now confirm reset password token with regular mobile client scope
+                    self.setupTestConfiguration()
+
+                    Customer.resetPassword(token: token, newPassword: "password", storeKey: "in-store-customer-test", result: { result in
+                        if let response = result.json, let email = response["email"] as? String {
+                            XCTAssert(result.isSuccess)
+                            XCTAssertEqual(email, username)
+                            resetPasswordExpectation.fulfill()
+                        }
+                    })
+                }
+            }
+
+            let request = TestCustomer.request(url: "\(path)password-token", method: .post, json: ["email": username], headers: TestCustomer.headers(token))
+
+            TestCustomer.perform(request: request) { (response: Result<NoMapping>) in
+                customerResult(response)
+            }
+        }
+
+        waitForExpectations(timeout: 10, handler: nil)
+    }
+
+    func testVerifyEmailInStore() {
+
+        let verifyEmailExpectation = expectation(description: "verify email expectation")
+
+        let username = "swift.sdk.test.in.store.user@commercetools.com"
+        let password = "password"
+
+        // For generating account activation token we need higher privileges
+        setupProjectManagementConfiguration()
+
+        // Obtain password reset token
+        AuthManager.sharedInstance.token { token, error in
+            guard let token = token, let path = TestCustomer.fullPath() else {
+                return
+            }
+
+            // First query for the UUID of the user we want to activate
+            TestCustomer.query(predicates: ["email=\"\(username)\""], result: { result in
+                if let response = result.json, let results = response["results"] as? [[String: AnyObject]],
+                   let id = results.first?["id"] as? String, result.isSuccess {
+
+                    let customerResult: ((Commercetools.Result<NoMapping>) -> Void) = { result in
+                        if let response = result.json, let token = response["value"] as? String, result.isSuccess {
+
+                            // Confirm email verification token with regular mobile client scope
+                            self.setupTestConfiguration()
+                            AuthManager.sharedInstance.loginCustomer(username: username, password: password, storeKey: "in-store-customer-test", completionHandler: { _ in})
+
+                            Customer.verifyEmail(token: token, storeKey: "in-store-customer-test", result: { result in
                                 if let response = result.json, let email = response["email"] as? String {
                                     XCTAssert(result.isSuccess)
                                     XCTAssertEqual(email, username)


### PR DESCRIPTION
Added support for in-store helpers available for the me endpoints for the customer.

Currently, the client needs to specify the `storeKey` with every call to any of the store-specific methods. @cneijenhuis do you think the SDK should perhaps have a `store` property, and once set, include it automatically in all store-specific subsequent requests?