### PR TITLE
Fixed a bug where the completionHandler was not called

### DIFF
--- a/Source/AuthManager.swift
+++ b/Source/AuthManager.swift
@@ -278,6 +278,7 @@ open class AuthManager {
         serialQueue.addOperation {
             guard self.accessToken != nil else {
                 self.clearAllTokens()
+                completionHandler(nil, nil)
                 return
             }
 


### PR DESCRIPTION
I had an issue calling `Cart.active` not returning a Result to me. This line was the case. The completionHandler is not called in case of `self.accessToken == nil`.

What kind of Error should be returned in this case, i leave up to you